### PR TITLE
fix relative paths

### DIFF
--- a/crates/sui-prover/src/build_model.rs
+++ b/crates/sui-prover/src/build_model.rs
@@ -48,11 +48,11 @@ fn reroot_path(path: Option<&Path>) -> anyhow::Result<PathBuf> {
     let path = path
         .map(Path::canonicalize)
         .unwrap_or_else(|| PathBuf::from(".").canonicalize())?;
-    // Always root ourselves to the package root, and then compile relative to that.
+    // Find the package root without changing the current directory
     let rooted_path = SourcePackageLayout::try_find_root(&path)?;
-    std::env::set_current_dir(rooted_path)?;
-
-    Ok(PathBuf::from("."))
+    
+    // Return the absolute path to the package root instead of changing cwd
+    Ok(rooted_path)
 }
 
 #[allow(dead_code)] // This function is used in external cli


### PR DESCRIPTION
Relative paths are broken. This makes it so `--path relative/path` works. The issue is that anything given to --path will be relative with respect to the absolute path based on a `cd` into the given path.

This also fixes internal tool `--path` to work with relative paths