### PR TITLE
fix relative paths output path

### DIFF
--- a/crates/move-prover-boogie-backend/src/generator.rs
+++ b/crates/move-prover-boogie-backend/src/generator.rs
@@ -482,13 +482,24 @@ pub fn create_and_process_bytecode(
         Path::new(s).file_name().unwrap().to_str().unwrap()
     });
 
+    let dump_dir = options
+        .move_sources
+        .first()
+        .map(|s| Path::new(s))
+        .map(|p| if p.is_file() { p.parent().unwrap_or(Path::new(".")) } else { p })
+        .unwrap_or(Path::new("."));
+
+    if options.prover.dump_bytecode {
+        fs::create_dir_all(dump_dir).expect("create dump directory");
+    }
+
     // Add function targets for all functions in the environment.
     for module_env in env.get_modules() {
         if module_env.is_target() {
             info!("preparing module {}", module_env.get_full_name_str());
         }
         if options.prover.dump_bytecode {
-            let dump_file = output_dir.join(format!("{}.mv.disas", output_prefix));
+            let dump_file = dump_dir.join(format!("{}.mv.disas", output_prefix));
             fs::write(&dump_file, module_env.disassemble()).expect("dumping disassembled module");
         }
         for func_env in module_env.get_functions() {
@@ -504,7 +515,7 @@ pub fn create_and_process_bytecode(
     };
 
     let res = if options.prover.dump_bytecode {
-        let dump_file_base = output_dir
+        let dump_file_base = dump_dir
             .join(output_prefix)
             .into_os_string()
             .into_string()

--- a/crates/move-prover-lean-backend/src/generator.rs
+++ b/crates/move-prover-lean-backend/src/generator.rs
@@ -178,13 +178,24 @@ pub fn create_and_process_bytecode(
         Path::new(s).file_name().unwrap().to_str().unwrap()
     });
 
+    let dump_dir = options
+        .move_sources
+        .first()
+        .map(|s| Path::new(s))
+        .map(|p| if p.is_file() { p.parent().unwrap_or(Path::new(".")) } else { p })
+        .unwrap_or(Path::new("."));
+
+    if options.prover.dump_bytecode {
+        fs::create_dir_all(dump_dir).expect("create dump directory");
+    }
+
     // Add function targets for all functions in the environment.
     for module_env in env.get_modules() {
         if module_env.is_target() {
             info!("preparing module {}", module_env.get_full_name_str());
         }
         if options.prover.dump_bytecode {
-            let dump_file = output_dir.join(format!("{}.mv.disas", output_prefix));
+            let dump_file = dump_dir.join(format!("{}.mv.disas", output_prefix));
             fs::write(&dump_file, module_env.disassemble()).expect("dumping disassembled module");
         }
         for func_env in module_env.get_functions() {
@@ -200,7 +211,7 @@ pub fn create_and_process_bytecode(
     };
 
     let res = if options.prover.dump_bytecode {
-        let dump_file_base = output_dir
+        let dump_file_base = dump_dir
             .join(output_prefix)
             .into_os_string()
             .into_string()

--- a/crates/sui-prover/src/build_model.rs
+++ b/crates/sui-prover/src/build_model.rs
@@ -44,7 +44,7 @@ fn resolve_lock_file_path(
     Ok(build_config)
 }
 
-fn reroot_path(path: Option<&Path>) -> anyhow::Result<PathBuf> {
+pub fn reroot_path(path: Option<&Path>) -> anyhow::Result<PathBuf> {
     let path = path
         .map(Path::canonicalize)
         .unwrap_or_else(|| PathBuf::from(".").canonicalize())?;

--- a/crates/sui-prover/src/main.rs
+++ b/crates/sui-prover/src/main.rs
@@ -51,8 +51,13 @@ async fn main() {
     let bin_name = env!("CARGO_BIN_NAME");
     let args = Args::parse();
 
+    let log_file_base = match crate::build_model::reroot_path(args.package_path.as_deref()) {
+        Ok(pkg_root) => pkg_root.join(format!("{bin_name}.log")).to_string_lossy().to_string(),
+        Err(_) => format!("{bin_name}.log"),
+    };
+
     let _guard = telemetry_subscribers::TelemetryConfig::new("sui-prover")
-        .with_log_file(&format!("{bin_name}.log"))
+        .with_log_file(&log_file_base)
         .with_log_level("debug")
         .with_env()
         .init();

--- a/crates/sui-prover/src/prove.rs
+++ b/crates/sui-prover/src/prove.rs
@@ -167,20 +167,20 @@ pub async fn execute(
     let model = build_model(path, Some(build_config))?;
 
     if matches!(general_config.backend, BackendOptions::Boogie) {
-        execute_backend_boogie(model, &general_config, boogie_config, filter).await
+        execute_backend_boogie(path, model, &general_config, boogie_config, filter).await
     } else {
-        execute_backend_lean(model, &general_config).await
+        execute_backend_lean(path, model, &general_config).await
     }
 }
 
 async fn execute_backend_boogie(
+    path: Option<&Path>,
     model: GlobalEnv,
     general_config: &GeneralConfig,
     boogie_config: Option<String>,
     filter: TargetFilterOptions
 ) -> anyhow::Result<()> {
     let mut options = move_prover_boogie_backend::generator_options::Options::default();
-    // don't spawn async tasks when running Boogie--causes a crash if we do
     options.backend.sequential_task = true;
     options.backend.use_array_theory = general_config.use_array_theory;
     options.backend.keep_artifacts = general_config.keep_temp;
@@ -196,6 +196,11 @@ async fn execute_backend_boogie(
     options.filter = filter;
     options.prover.dump_bytecode = general_config.dump_bytecode;
     options.prover.enable_conditional_merge_insertion = general_config.enable_conditional_merge_insertion;
+
+    if let Ok(pkg_root) = crate::build_model::reroot_path(path) {
+        options.move_sources = vec![pkg_root.to_string_lossy().to_string()];
+        options.output_path = pkg_root.join("output").to_string_lossy().to_string();
+    }
 
     if general_config.explain {
         let mut error_writer = Buffer::no_color();
@@ -218,6 +223,7 @@ async fn execute_backend_boogie(
 }
 
 async fn execute_backend_lean(
+    path: Option<&Path>,
     model: GlobalEnv,
     general_config: &GeneralConfig) -> anyhow::Result<()> {
     let mut options = move_prover_lean_backend::generator_options::Options::default();
@@ -227,6 +233,10 @@ async fn execute_backend_lean(
         LevelFilter::Info
     };
     options.prover.enable_conditional_merge_insertion = general_config.enable_conditional_merge_insertion;
+    if let Ok(pkg_root) = crate::build_model::reroot_path(path) {
+        options.move_sources = vec![pkg_root.to_string_lossy().to_string()];
+        options.output_path = pkg_root.join("output").to_string_lossy().to_string();
+    }
     let mut error_writer = Buffer::no_color();
     match move_prover_lean_backend::generator::run_move_prover_with_model(options, &model, &mut error_writer) {
         Ok(_) => {


### PR DESCRIPTION
In e5bd861b7218fe1ba8743a6eb5afbc9bfd80f02e it's possible to specify relative paths for the prover. Problem is that change meant that generated files (`output`,`.bytecode`,etc) would end up in the _current_ directory, not the `--path` destination. This fixes it to propagate the resolved relative path through all parts where we output generated code.

(nothing in our tests/CI was affected because we always ran `sui-prover` in the project root dir)