### PR TITLE
conditional insertions: better pass logic

### DIFF
--- a/crates/move-stackless-bytecode/src/conditional_merge_insertion.rs
+++ b/crates/move-stackless-bytecode/src/conditional_merge_insertion.rs
@@ -48,7 +48,7 @@ impl ConditionalMergeInsertionProcessor {
     }
 
     // Dominator-based merge detection for a branch at pc.
-    // Returns (cond_temp, then_start_pc, merge_block_start_pc) if we can determine a merge.
+    // Returns the merge label if we can determine a valid merge pattern.
     //
     // Recall the immediate postdominator of the branch corresponds to the
     // structural join. For SSA-style placement of `if_then_else` (phi) per
@@ -56,181 +56,27 @@ impl ConditionalMergeInsertionProcessor {
     // merges at those DF nodes. This function currently finds the structural
     // join (later phases can refine per-var merge placement using DF).
     fn find_merge_by_dominators(
+        &self,
         code: &[Bytecode],
         back_cfg: &StacklessControlFlowGraph,
         branch_pc: usize,
-    ) -> Option<(usize, usize, usize)> {
-        let (then_label, cond) = match &code[branch_pc] {
-            Bytecode::Branch(_, tl, _el, cond) => (tl, *cond),
-            _ => return None,
-        };
-
+    ) -> Option<Label> {
         let labels = Bytecode::label_offsets(code);
-        let then_pc = *labels.get(then_label)?;
         let branch_block = StacklessControlFlowGraph::pc_to_block(back_cfg, branch_pc as u16)?;
-
         // Compute merge block as immediate post-dominator of the branch block using
         // reversed-graph dominator analysis (postdominators of the original graph).
         let merge_block =
             StacklessControlFlowGraph::find_immediate_post_dominator(back_cfg, branch_block)?;
         let merge_pc = StacklessControlFlowGraph::block_start_pc(back_cfg, merge_block)?;
 
-        Some((cond, then_pc as usize, merge_pc as usize))
+        // Find the label that corresponds to merge_pc
+        labels
+            .iter()
+            .find(|(_, &pc)| pc == merge_pc)
+            .map(|(label, _)| *label)
     }
 
-    // Validate that the computed merge is the else_label (i.e., if-with-fallthrough),
-    // scan the then-block for a simple single-assignment pattern, and if matched,
-    // record a pending insertion at the merge label.
-    // Returns: (var, then_src, else_src, insertion_label) - None for else_src means use current_val
-    fn find_merge_for_fallthrough(
-        &self,
-        orig_code: &[Bytecode],
-        else_label: Label,
-        then_start: usize,
-        merge_pc: usize,
-    ) -> Option<(usize, usize, Option<usize>, Label)> {
-        let labels = Bytecode::label_offsets(orig_code);
-        let Some(else_pc) = labels.get(&else_label) else {
-            return None;
-        };
-        if merge_pc != *else_pc as usize {
-            // This is not a fallthrough pattern, try if-then-else pattern
-            return self.find_merge_for_if_then_else(orig_code, else_label, then_start, merge_pc);
-        }
-
-        // Scan inside then-block [then_start, merge_pc).
-        let mut scan_pc = then_start;
-        let mut last_assign_per_var: BTreeMap<usize, usize> = BTreeMap::new();
-        let mut last_assigned_var: Option<usize> = None;
-        let mut ok_jump_to_else = false;
-        let mut saw_uncond_branch = false;
-        let mut simple_then = true;
-        while scan_pc < orig_code.len() && scan_pc < merge_pc {
-            match &orig_code[scan_pc] {
-                Bytecode::Assign(_, dst, src, _) => {
-                    // Track last assignment to each variable and remember the most recent assignment
-                    last_assign_per_var.insert(*dst, *src);
-                    last_assigned_var = Some(*dst);
-                }
-                Bytecode::Call(_, dests, _op, _srcs, _aa) if !dests.is_empty() => {
-                    // Track call result as assignment to destination
-                    let var = dests[0]; // Dest must exist, i.e., return value of call assigned.
-                    last_assign_per_var.insert(var, var);
-                    last_assigned_var = Some(var);
-                }
-                Bytecode::Call(_, _dests, Operation::TraceLocal(_), _srcs, _aa) => {
-                    // TODO(rvantondeR): TraceLocals are fine, and so are other debugging ops (which we should add).
-                }
-                Bytecode::Branch(..) => {
-                    simple_then = false; // TODO(rvantonder): reject if nested conditional in then
-                    break;
-                }
-                Bytecode::Label(..) => {
-                    if scan_pc != then_start {
-                        simple_then = false; // TODO(rvantonder): reject if extra label inside then
-                        break;
-                    }
-                }
-                Bytecode::Load(..) => {}
-                _ => {
-                    // Ultra conservative: reject any other bytecode ops in the block so we don't break things
-                    simple_then = false;
-                    break;
-                }
-            }
-            if orig_code[scan_pc].is_unconditional_branch() {
-                saw_uncond_branch = true;
-                if let Bytecode::Jump(_, label) = &orig_code[scan_pc] {
-                    ok_jump_to_else = *label == else_label;
-                } else {
-                    // Punt: this is an unconditional branch that doesn't jump to where we expect.
-                    ok_jump_to_else = false;
-                }
-                break;
-            }
-            scan_pc += 1;
-        }
-        if !saw_uncond_branch {
-            // Accept implicit fallthrough into merge label.
-            ok_jump_to_else = true;
-        }
-
-        // Use the last assigned variable (most recent assignment in the then-block)
-        let pattern_ok = simple_then && ok_jump_to_else && last_assigned_var.is_some();
-        if pattern_ok {
-            let var = last_assigned_var.unwrap();
-            let then_src = *last_assign_per_var.get(&var).unwrap();
-            return Some((var, then_src, None, else_label));
-        }
-        None
-    }
-
-    // Handle if-then-else pattern where both then and else blocks have assignments
-    // and both jump to a common merge point (not fallthrough)
-    // Returns: (var, then_src, else_src, merge_label) for if-then-else patterns
-    fn find_merge_for_if_then_else(
-        &self,
-        orig_code: &[Bytecode],
-        else_label: Label,
-        then_start: usize,
-        _merge_pc: usize,
-    ) -> Option<(usize, usize, Option<usize>, Label)> {
-        let labels = Bytecode::label_offsets(orig_code);
-        let Some(else_pc) = labels.get(&else_label) else {
-            return None;
-        };
-        let else_start = *else_pc as usize;
-
-        // Find the merge label by following the then-block's exit jump
-        let mut merge_label: Option<Label> = None;
-        for pc in then_start..else_start {
-            if pc < orig_code.len() {
-                if let Bytecode::Jump(_, label) = &orig_code[pc] {
-                    merge_label = Some(*label);
-                    break;
-                }
-            }
-        }
-
-        let Some(merge_label) = merge_label else {
-            return None;
-        };
-
-        // Scan then-block [then_start, else_start)
-        let then_assignment = self.block_permitted(orig_code, then_start, else_start);
-        if then_assignment.is_none() {
-            return None;
-        }
-
-        // For else-block, scan from else_start until we reach the merge label
-        let mut else_end = orig_code.len();
-        for pc in else_start..orig_code.len() {
-            if let Bytecode::Label(_, label) = &orig_code[pc] {
-                if *label == merge_label {
-                    else_end = pc;
-                    break;
-                }
-            }
-        }
-
-        let else_assignment = self.block_permitted(orig_code, else_start, else_end);
-        if else_assignment.is_none() {
-            return None;
-        }
-
-        let (then_var, then_src) = then_assignment.unwrap();
-        let (else_var, else_src) = else_assignment.unwrap();
-
-        // Both blocks must assign to the same variable
-        if then_var != else_var {
-            return None;
-        }
-
-        // Return if-then-else pattern with explicit else_src and merge_label
-        Some((then_var, then_src, Some(else_src), merge_label))
-    }
-
-    // Helper function to scan a block for simple assignments, similar to the logic in find_merge_for_fallthrough
+    // Helper function to scan a block for simple assignments
     fn block_permitted(
         &self,
         orig_code: &[Bytecode],
@@ -285,17 +131,70 @@ impl ConditionalMergeInsertionProcessor {
 
         None
     }
+
+    // Build conditional insert using postdominator analysis results
+    // Handles both if-then (fallthrough) and if-then-else patterns uniformly
+    fn build_conditional_insert(
+        &self,
+        code: &[Bytecode],
+        then_label: Label,
+        else_label: Label,
+        merge_label: Label,
+        cond_idx: usize,
+        src_attr: AttrId,
+        current_val: &BTreeMap<usize, usize>,
+    ) -> Option<(Label, Insertion)> {
+        let labels = Bytecode::label_offsets(code);
+        let then_pc = *labels.get(&then_label)? as usize;
+        let else_pc = *labels.get(&else_label)? as usize;
+        let merge_pc = *labels.get(&merge_label)? as usize;
+
+        // Scan the then-block: from then_pc to else_pc
+        let then_assignment = self.block_permitted(code, then_pc, else_pc)?;
+        let (then_var, then_src) = then_assignment;
+
+        // Scan the else-block: from else_pc to merge_pc
+        // If else_pc == merge_pc, there's no else block (pure fallthrough)
+        let else_assignment = if else_pc < merge_pc {
+            self.block_permitted(code, else_pc, merge_pc)
+        } else {
+            None
+        };
+
+        let else_var = match else_assignment {
+            Some((else_var_from_block, else_src)) => {
+                // TODO(rvantonder): restriction: both blocks assign and must be same var
+                if then_var != else_var_from_block {
+                    return None;
+                }
+                // If-then-else pattern with explicit else source (same var)
+                else_src
+            }
+            None => {
+                // If-then (fallthrough): current_val is fallthrough source var
+                *current_val.get(&then_var).unwrap_or(&then_var)
+            }
+        };
+
+        let insertion = Insertion {
+            dest_var: then_var,
+            cond: cond_idx,
+            then_var: then_src,
+            src_attr,
+            else_var,
+        };
+
+        Some((merge_label, insertion))
+    }
 }
 
 #[derive(Clone, Debug)]
 struct Insertion {
-    var: usize,
-    cond: usize,
-    then_src: usize,
-    // attribute to inherit location/debug context from (taken from Branch)
     src_attr: AttrId,
-    // For if-then-else patterns, store the explicit else_src instead of using current_val
-    explicit_else_src: Option<usize>,
+    dest_var: usize,
+    cond: usize,
+    then_var: usize,
+    else_var: usize,
 }
 
 impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
@@ -351,72 +250,58 @@ impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
                             // Set location/debug context from the originating branch instruction
                             builder.set_loc_from_attr(ins.src_attr);
                             // Allocate a fresh temp of same type as `var`
-                            let var_ty = builder.get_local_type(ins.var);
+                            let var_ty = builder.get_local_type(ins.dest_var);
                             let new_temp = builder.new_temp(var_ty);
-
-                            // Use the captured else_src (always available now)
-                            let else_src = ins.explicit_else_src.expect("conditional_merge_insertion: explicit_else_src should always be Some here");
-
                             builder.set_next_debug_comment(format!(
                                 "conditional_merge_insertion: t{} := if_then_else(t{}, t{}, t{})",
-                                new_temp, ins.cond, ins.then_src, else_src
+                                new_temp, ins.cond, ins.then_var, ins.else_var
                             ));
                             builder.emit_with(|id| {
                                 Bytecode::Call(
                                     id,
                                     vec![new_temp],
                                     Operation::IfThenElse,
-                                    vec![ins.cond, ins.then_src, else_src],
+                                    vec![ins.cond, ins.then_var, ins.else_var],
                                     None,
                                 )
                             });
 
                             builder.set_next_debug_comment(format!(
                                 "conditional_merge_insertion: merge assign t{} := t{}",
-                                ins.var, new_temp
+                                ins.dest_var, new_temp
                             ));
                             builder.emit_with(|id| {
-                                Bytecode::Assign(id, ins.var, new_temp, AssignKind::Store)
+                                Bytecode::Assign(id, ins.dest_var, new_temp, AssignKind::Store)
                             });
-                            current_val.insert(ins.var, new_temp);
+                            current_val.insert(ins.dest_var, new_temp);
                         }
                     }
                 }
-                Bytecode::Branch(attr, _then_label, else_label, _cond) => {
-                    // Only processes insertion for strict `if (cond) { ... }` with fallthrough merge:
-                    // Use dominator-based merge detection to find the merge, then validate
-                    // the then-block is simple and contains exactly one write.
-                    let dominator =
-                        Self::find_merge_by_dominators(&orig_code, back_cfg.as_ref().unwrap(), pc);
-                    if let Some((cond_idx, then_start, merge_pc)) = dominator {
-                        let merge_point = self.find_merge_for_fallthrough(
-                            &orig_code, else_label, then_start, merge_pc,
-                        );
+                Bytecode::Branch(attr, then_label, else_label, cond_idx) => {
+                    let merge_label =
+                        self.find_merge_by_dominators(&orig_code, back_cfg.as_ref().unwrap(), pc);
 
-                        if let Some((var, then_src, explicit_else_src, insertion_label)) =
-                            merge_point
-                        {
-                            // For fallthrough patterns, capture the current else_src value now
-                            let final_else_src = if explicit_else_src.is_some() {
-                                explicit_else_src
-                            } else {
-                                // Fallthrough pattern: use current_val at branch time
-                                Some(*current_val.get(&var).unwrap_or(&var))
-                            };
-
-                            pending_inserts
-                                .entry(insertion_label)
-                                .or_default()
-                                .push(Insertion {
-                                    var,
-                                    cond: cond_idx,
-                                    then_src,
-                                    src_attr: attr,
-                                    explicit_else_src: final_else_src,
-                                });
-                        }
+                    if merge_label.is_none() {
+                        builder.emit(Bytecode::Branch(attr, then_label, else_label, cond_idx));
+                        continue;
                     }
-                    builder.emit(Bytecode::Branch(attr, _then_label, else_label, _cond))
+                    // Invariant: merge_label is Some
+                    let merge_label = merge_label.unwrap();
+                    if let Some((insertion_label, insertion)) = self.build_conditional_insert(
+                        &orig_code,
+                        then_label,
+                        else_label,
+                        merge_label,
+                        cond_idx,
+                        attr,
+                        &current_val,
+                    ) {
+                        pending_inserts
+                            .entry(insertion_label)
+                            .or_default()
+                            .push(insertion);
+                    }
+                    builder.emit(Bytecode::Branch(attr, then_label, else_label, cond_idx))
                 }
                 Bytecode::Assign(attr, dst, src, kind) => {
                     // Track latest value of destination


### PR DESCRIPTION
This cleans up a bunch of things to prepare handling more general cases. It doesn't add anything new. Overall motivation is to have if-then and if-then-else branches both use the `merge_label` returned by postdominator analysis (and removes the hacky thing about following jumps to get this). The other changes are a follow-on of that change.

