### PR TITLE
conditional insertions: fresh variables in block branches

### DIFF
--- a/crates/move-stackless-bytecode/src/conditional_merge_insertion.rs
+++ b/crates/move-stackless-bytecode/src/conditional_merge_insertion.rs
@@ -143,6 +143,7 @@ impl ConditionalMergeInsertionProcessor {
         cond_idx: usize,
         src_attr: AttrId,
         current_val: &BTreeMap<usize, usize>,
+        builder: &mut FunctionDataBuilder,
     ) -> Option<(Label, Insertion)> {
         let labels = Bytecode::label_offsets(code);
         let then_pc = *labels.get(&then_label)? as usize;
@@ -176,12 +177,25 @@ impl ConditionalMergeInsertionProcessor {
             }
         };
 
+        let var_ty = builder.get_local_type(then_var);
+        let fresh_then_var = builder.new_temp(var_ty.clone());
+        let mut fresh_vars_in_then = BTreeMap::new();
+        fresh_vars_in_then.insert(then_var, fresh_then_var);
+
+        let mut fresh_vars_in_else = BTreeMap::new();
+        if let Some((else_var_from_block, _)) = else_assignment {
+            let fresh_else_var = builder.new_temp(var_ty);
+            fresh_vars_in_else.insert(else_var_from_block, fresh_else_var);
+        }
+
         let insertion = Insertion {
             dest_var: then_var,
             cond: cond_idx,
             then_var: then_src,
             src_attr,
             else_var,
+            fresh_vars_in_then,
+            fresh_vars_in_else,
         };
 
         Some((merge_label, insertion))
@@ -195,6 +209,8 @@ struct Insertion {
     cond: usize,
     then_var: usize,
     else_var: usize,
+    fresh_vars_in_then: BTreeMap<usize, usize>,
+    fresh_vars_in_else: BTreeMap<usize, usize>,
 }
 
 impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
@@ -239,12 +255,22 @@ impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
         let mut pending_inserts: BTreeMap<Label, Vec<Insertion>> = BTreeMap::new();
         let back_cfg = Some(StacklessControlFlowGraph::new_backward(&orig_code, false));
 
+        let mut active_fresh_vars: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut label_to_fresh_vars: BTreeMap<Label, BTreeMap<usize, usize>> = BTreeMap::new();
+
         let mut pc = 0; // TODO(@rvantonder): can we do this pass without pc?
         for bc in mem::take(&mut builder.data.code) {
             match bc {
                 // Check labels for inserting if_then_else(...)
                 Bytecode::Label(attr_id, label) => {
                     builder.emit(Bytecode::Label(attr_id, label));
+
+                    if let Some(fresh_vars_map) = label_to_fresh_vars.get(&label) {
+                        active_fresh_vars = fresh_vars_map.clone();
+                    } else {
+                        active_fresh_vars.clear();
+                    }
+
                     if let Some(list) = pending_inserts.remove(&label) {
                         for ins in list {
                             // Set location/debug context from the originating branch instruction
@@ -252,16 +278,27 @@ impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
                             // Allocate a fresh temp of same type as `var`
                             let var_ty = builder.get_local_type(ins.dest_var);
                             let new_temp = builder.new_temp(var_ty);
+
+                            let fresh_then_var = ins
+                                .fresh_vars_in_then
+                                .get(&ins.dest_var)
+                                .unwrap_or(&ins.then_var);
+
+                            let fresh_else_var = ins
+                                .fresh_vars_in_else
+                                .get(&ins.dest_var)
+                                .unwrap_or(&ins.else_var);
+
                             builder.set_next_debug_comment(format!(
                                 "conditional_merge_insertion: t{} := if_then_else(t{}, t{}, t{})",
-                                new_temp, ins.cond, ins.then_var, ins.else_var
+                                new_temp, ins.cond, fresh_then_var, fresh_else_var
                             ));
                             builder.emit_with(|id| {
                                 Bytecode::Call(
                                     id,
                                     vec![new_temp],
                                     Operation::IfThenElse,
-                                    vec![ins.cond, ins.then_var, ins.else_var],
+                                    vec![ins.cond, *fresh_then_var, *fresh_else_var],
                                     None,
                                 )
                             });
@@ -295,7 +332,24 @@ impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
                         cond_idx,
                         attr,
                         &current_val,
+                        &mut builder,
                     ) {
+                        let mut fresh_vars_for_then_block = BTreeMap::new();
+                        fresh_vars_for_then_block.insert(
+                            insertion.dest_var,
+                            insertion.fresh_vars_in_then[&insertion.dest_var],
+                        );
+                        label_to_fresh_vars.insert(then_label, fresh_vars_for_then_block);
+
+                        // Add fresh variables for else-branch if it exists
+                        if !insertion.fresh_vars_in_else.is_empty() {
+                            let mut fresh_vars_for_else_block = BTreeMap::new();
+                            for (&var, &fresh_var) in &insertion.fresh_vars_in_else {
+                                fresh_vars_for_else_block.insert(var, fresh_var);
+                            }
+                            label_to_fresh_vars.insert(else_label, fresh_vars_for_else_block);
+                        }
+
                         pending_inserts
                             .entry(insertion_label)
                             .or_default()
@@ -303,16 +357,22 @@ impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
                     }
                     builder.emit(Bytecode::Branch(attr, then_label, else_label, cond_idx))
                 }
-                Bytecode::Assign(attr, dst, src, kind) => {
-                    // Track latest value of destination
-                    current_val.insert(dst, src);
-                    builder.emit(Bytecode::Assign(attr, dst, src, kind))
+                Bytecode::Assign(attr, original_dst, src, kind) => {
+                    let fresh_dst = active_fresh_vars
+                        .get(&original_dst)
+                        .copied()
+                        .unwrap_or(original_dst);
+                    current_val.insert(original_dst, src); // Track latest rhs value of original dst
+                    builder.emit(Bytecode::Assign(attr, fresh_dst, src, kind))
                 }
-                Bytecode::Call(attr, dests, op, srcs, abort) if !dests.is_empty() => {
-                    // Dest now holds the produced value
-                    current_val.insert(dests[0], dests[0]);
-                    // Emit original instruction without moving fields (borrowed above)
-                    builder.emit(Bytecode::Call(attr, dests.clone(), op, srcs, abort))
+                Bytecode::Call(attr, dests, op, srcs, abort) if dests.len() == 1 => {
+                    let original_dest = dests[0];
+                    let actual_dest = active_fresh_vars
+                        .get(&original_dest)
+                        .copied()
+                        .unwrap_or(original_dest);
+                    current_val.insert(original_dest, original_dest);
+                    builder.emit(Bytecode::Call(attr, vec![actual_dest], op, srcs, abort))
                 }
                 bytecode => builder.emit(bytecode),
             }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/01_simple_if_conditional.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/01_simple_if_conditional.snap
@@ -41,6 +41,7 @@ public fun test::f($t0|a: u64): u64 {
      var $t4: bool
      var $t5: u64
      var $t6: u64
+     var $t7: u64
   0: $t2 := 0
   1: $t1 := $t2
   2: $t3 := 0
@@ -48,11 +49,11 @@ public fun test::f($t0|a: u64): u64 {
   4: if ($t4) goto 5 else goto 8
   5: label L1
   6: $t5 := 10
-  7: $t1 := *($t2, $t5)
+  7: $t6 := *($t2, $t5)
   8: label L0
-     # conditional_merge_insertion: t6 := if_then_else(t4, t1, t2)
-  9: $t6 := if_then_else($t4, $t1, $t2)
-     # conditional_merge_insertion: merge assign t1 := t6
- 10: $t1 := $t6
+     # conditional_merge_insertion: t7 := if_then_else(t4, t6, t2)
+  9: $t7 := if_then_else($t4, $t6, $t2)
+     # conditional_merge_insertion: merge assign t1 := t7
+ 10: $t1 := $t7
  11: return $t1
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/02_consecutive_if_conditionals.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/02_consecutive_if_conditionals.snap
@@ -83,6 +83,9 @@ public fun test::f($t0|a: u64): u64 {
      var $t12: u64
      var $t13: u64
      var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
   0: $t2 := 0
   1: $t1 := $t2
   2: $t3 := 0
@@ -90,33 +93,33 @@ public fun test::f($t0|a: u64): u64 {
   4: if ($t4) goto 5 else goto 8
   5: label L1
   6: $t5 := 10
-  7: $t1 := *($t2, $t5)
+  7: $t12 := *($t2, $t5)
   8: label L0
-     # conditional_merge_insertion: t12 := if_then_else(t4, t1, t2)
-  9: $t12 := if_then_else($t4, $t1, $t2)
-     # conditional_merge_insertion: merge assign t1 := t12
- 10: $t1 := $t12
+     # conditional_merge_insertion: t13 := if_then_else(t4, t12, t2)
+  9: $t13 := if_then_else($t4, $t12, $t2)
+     # conditional_merge_insertion: merge assign t1 := t13
+ 10: $t1 := $t13
  11: $t6 := 5
  12: $t7 := >($t0, $t6)
  13: if ($t7) goto 14 else goto 17
  14: label L3
  15: $t8 := 20
- 16: $t1 := *($t1, $t8)
+ 16: $t14 := *($t1, $t8)
  17: label L2
-     # conditional_merge_insertion: t13 := if_then_else(t7, t1, t12)
- 18: $t13 := if_then_else($t7, $t1, $t12)
-     # conditional_merge_insertion: merge assign t1 := t13
- 19: $t1 := $t13
+     # conditional_merge_insertion: t15 := if_then_else(t7, t14, t13)
+ 18: $t15 := if_then_else($t7, $t14, $t13)
+     # conditional_merge_insertion: merge assign t1 := t15
+ 19: $t1 := $t15
  20: $t9 := 10
  21: $t10 := >($t0, $t9)
  22: if ($t10) goto 23 else goto 26
  23: label L5
  24: $t11 := 30
- 25: $t1 := *($t1, $t11)
+ 25: $t16 := *($t1, $t11)
  26: label L4
-     # conditional_merge_insertion: t14 := if_then_else(t10, t1, t13)
- 27: $t14 := if_then_else($t10, $t1, $t13)
-     # conditional_merge_insertion: merge assign t1 := t14
- 28: $t1 := $t14
+     # conditional_merge_insertion: t17 := if_then_else(t10, t16, t15)
+ 27: $t17 := if_then_else($t10, $t16, $t15)
+     # conditional_merge_insertion: merge assign t1 := t17
+ 28: $t1 := $t17
  29: return $t1
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/03_multiple_assignments_in_then.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/03_multiple_assignments_in_then.snap
@@ -40,17 +40,18 @@ fun ConditionalMergeInsertionTest::multiple_assignments_in_then($t0|cond: bool, 
      var $t4: u128
      var $t5: u8
      var $t6: u128
+     var $t7: u128
   0: $t2 := $t1
   1: if ($t0) goto 2 else goto 7
   2: label L1
   3: $t3 := 38992368544603139932233054999993551
   4: $t4 := *($t1, $t3)
   5: $t5 := 96
-  6: $t2 := >>($t4, $t5)
+  6: $t6 := >>($t4, $t5)
   7: label L0
-     # conditional_merge_insertion: t6 := if_then_else(t0, t2, t1)
-  8: $t6 := if_then_else($t0, $t2, $t1)
-     # conditional_merge_insertion: merge assign t2 := t6
-  9: $t2 := $t6
+     # conditional_merge_insertion: t7 := if_then_else(t0, t6, t1)
+  8: $t7 := if_then_else($t0, $t6, $t1)
+     # conditional_merge_insertion: merge assign t2 := t7
+  9: $t2 := $t7
  10: return $t2
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/04_if_then_else_with_assignments.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/04_if_then_else_with_assignments.snap
@@ -94,6 +94,9 @@ fun ConditionalMergeInsertionTest::if_then_else_with_assignments($t0|cond: bool,
      var $t11: u8
      var $t12: u128
      var $t13: u128
+     var $t14: u128
+     var $t15: u128
+     var $t16: u128
   0: $t4 := 1
   1: $t5 := &($t1, $t4)
   2: $t6 := 0
@@ -101,26 +104,26 @@ fun ConditionalMergeInsertionTest::if_then_else_with_assignments($t0|cond: bool,
   4: if ($t7) goto 5 else goto 9
   5: label L1
   6: $t8 := 79232123823359799118286999567
-  7: $t2 := $t8
+  7: $t12 := $t8
   8: goto 12
   9: label L0
  10: $t9 := 79228162514264337593543950336
- 11: $t2 := $t9
+ 11: $t13 := $t9
  12: label L2
-     # conditional_merge_insertion: t12 := if_then_else(t7, t8, t9)
- 13: $t12 := if_then_else($t7, $t8, $t9)
-     # conditional_merge_insertion: merge assign t2 := t12
- 14: $t2 := $t12
+     # conditional_merge_insertion: t14 := if_then_else(t7, t12, t13)
+ 13: $t14 := if_then_else($t7, $t12, $t13)
+     # conditional_merge_insertion: merge assign t2 := t14
+ 14: $t2 := $t14
  15: $t3 := $t2
  16: if ($t0) goto 17 else goto 21
  17: label L4
  18: $t10 := 38992368544603139932233054999993551
  19: $t11 := 96
- 20: $t3 := ConditionalMergeInsertionTest::helper_function($t2, $t10, $t11)
+ 20: $t15 := ConditionalMergeInsertionTest::helper_function($t2, $t10, $t11)
  21: label L3
-     # conditional_merge_insertion: t13 := if_then_else(t0, t3, t2)
- 22: $t13 := if_then_else($t0, $t3, $t2)
-     # conditional_merge_insertion: merge assign t3 := t13
- 23: $t3 := $t13
+     # conditional_merge_insertion: t16 := if_then_else(t0, t15, t2)
+ 22: $t16 := if_then_else($t0, $t15, $t2)
+     # conditional_merge_insertion: merge assign t3 := t16
+ 23: $t3 := $t16
  24: return $t3
 }


### PR DESCRIPTION
variables previously reused and assigned inside block branches are now mapped to fresh variables, and these are referenced in the `if_then_else(...)` insertions. snapshot updates show the change. 

stacked on https://github.com/asymptotic-code/sui-prover/pull/210