### PR TITLE
conditional insertions: make more permissive

### DIFF
--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/09_early_ret.move
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/09_early_ret.move
@@ -1,0 +1,18 @@
+module 0x42::test {
+    public fun f(cond: bool): u64 {
+        let mut x = 1;
+        let mut y = 2;
+
+        if (cond) {
+            x = 99;  // Only x is assigned in then-block
+        } else {
+            y = 100; // Only y is assigned in else-block
+        };
+
+        if (!cond) {
+          return y
+        };
+
+        x * y
+    }
+}

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/09_early_ret.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/09_early_ret.snap
@@ -1,0 +1,93 @@
+---
+source: crates/move-stackless-bytecode/tests/testsuite.rs
+---
+============ initial translation from Move ================
+
+[variant baseline]
+public fun test::f($t0|cond: bool): u64 {
+     var $t1|x#1#0: u64
+     var $t2|y#1#0: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: bool
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+  0: $t3 := 1
+  1: $t1 := $t3
+  2: $t4 := 2
+  3: $t2 := $t4
+  4: $t5 := copy($t0)
+  5: if ($t5) goto 6 else goto 10
+  6: label L1
+  7: $t6 := 99
+  8: $t1 := $t6
+  9: goto 14
+ 10: label L0
+ 11: $t7 := 100
+ 12: $t2 := $t7
+ 13: goto 14
+ 14: label L2
+ 15: $t8 := move($t0)
+ 16: $t9 := !($t8)
+ 17: if ($t9) goto 18 else goto 21
+ 18: label L4
+ 19: $t10 := move($t2)
+ 20: return $t10
+ 21: label L3
+ 22: $t11 := move($t1)
+ 23: $t12 := move($t2)
+ 24: $t13 := *($t11, $t12)
+ 25: return $t13
+}
+
+============ after pipeline `conditional_merge_insertion` ================
+
+[variant baseline]
+public fun test::f($t0|cond: bool): u64 {
+     var $t1|x#1#0: u64
+     var $t2|y#1#0: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: bool
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+  0: $t3 := 1
+  1: $t1 := $t3
+  2: $t4 := 2
+  3: $t2 := $t4
+  4: if ($t0) goto 5 else goto 9
+  5: label L1
+  6: $t5 := 99
+  7: $t9 := $t5
+  8: goto 12
+  9: label L0
+ 10: $t6 := 100
+ 11: $t10 := $t6
+ 12: label L2
+     # conditional_merge_insertion: t11 := if_then_else(t0, t9, t3)
+ 13: $t11 := if_then_else($t0, $t9, $t3)
+     # conditional_merge_insertion: merge assign t1 := t11
+ 14: $t1 := $t11
+     # conditional_merge_insertion: t12 := if_then_else(t0, t4, t10)
+ 15: $t12 := if_then_else($t0, $t4, $t10)
+     # conditional_merge_insertion: merge assign t2 := t12
+ 16: $t2 := $t12
+ 17: $t7 := !($t0)
+ 18: if ($t7) goto 19 else goto 21
+ 19: label L4
+ 20: return $t2
+ 21: label L3
+ 22: $t8 := *($t1, $t2)
+ 23: return $t8
+}


### PR DESCRIPTION
Adds more specific logic for permitting when we add if_then_else expressions:

- checking some side-effecting operations for calls

- allow early returns to exist: we don't add if-then-else expressions since there is no merge point. previously we rejected the whole function for transformation, but in principle we're not doing any harm by inserting valid if-then-else expressions before an early return. E.g., if we added backend support for early returns (special casing) then we can still make use of any inserted if-then-else expressions

- other minor things