### PR TITLE
More mono fixes.

### DIFF
--- a/crates/move-stackless-bytecode/src/mono_analysis.rs
+++ b/crates/move-stackless-bytecode/src/mono_analysis.rs
@@ -237,7 +237,8 @@ impl MonoAnalysisProcessor {
                         is_mut: _,
                     } => {
                         analyzer.add_type_root(name);
-                        analyzer.add_type_root(value);
+                        // add the value type to Option instantiations
+                        analyzer.add_option_type(value);
                     }
                     NameValueInfo::NameOnly(name) => {
                         analyzer.add_type_root(name);
@@ -246,100 +247,78 @@ impl MonoAnalysisProcessor {
             }
         }
 
+        if let Some(vec_set_qid) = env.vec_set_qid() {
+            let vec_set_tys = analyzer
+                .info
+                .structs
+                .get(&vec_set_qid)
+                .map_or_else(BTreeSet::new, |set| set.clone());
+
+            // VecSet<T> uses vector<T> internally, so we need to add T to vec_inst
+            for tys in &vec_set_tys {
+                if let [t_ty] = tys.as_slice() {
+                    analyzer.info.vec_inst.insert(t_ty.clone());
+                    analyzer.add_type_root(t_ty);
+                }
+            }
+
+            // VecSet also uses vector<u64> internally for storing indices, so we need to add u64 to vec_inst
+            let has_vec_set = analyzer
+                .info
+                .structs
+                .get(&vec_set_qid)
+                .is_some_and(|set| !set.is_empty());
+
+            if has_vec_set {
+                analyzer.add_option_type(&Type::Primitive(move_model::ty::PrimitiveType::U64));
+            }
+        }
+
+        if let Some(vec_map_qid) = env.vec_map_qid() {
+            let vec_map_tys = analyzer
+                .info
+                .structs
+                .get(&vec_map_qid)
+                .map_or_else(BTreeSet::new, |set| set.clone());
+
+            // VecMap<K, V> uses vector<K> and vector<V> internally, so we need to add K and V to vec_inst
+            for tys in &vec_map_tys {
+                if let [k_ty, v_ty] = tys.as_slice() {
+                    analyzer.info.vec_inst.insert(k_ty.clone());
+                    analyzer.info.vec_inst.insert(v_ty.clone());
+                    analyzer.add_type_root(k_ty);
+                    // add the value type to Option instantiations
+                    analyzer.add_option_type(v_ty);
+                }
+            }
+
+            // VecMap also uses vec<u64> internally for storing indices, so we need to add u64 to vec_inst
+            let has_vec_map = analyzer
+                .info
+                .structs
+                .get(&vec_map_qid)
+                .is_some_and(|set| !set.is_empty());
+
+            if has_vec_map {
+                analyzer.add_option_type(&Type::Primitive(move_model::ty::PrimitiveType::U64));
+            }
+        }
+
+        // Add ID generation by default
+        if let Some(id_qid) = env.id_qid() {
+            analyzer.add_type_root(&Type::Datatype(id_qid.module_id, id_qid.id, vec![]));
+        }
+
+        if let Some(uid_qid) = env.uid_qid() {
+            analyzer.add_type_root(&Type::Datatype(uid_qid.module_id, uid_qid.id, vec![]));
+        }
+
         let Analyzer {
             mut info,
             done_types,
             ..
         } = analyzer;
         info.all_types = done_types;
-
-        if let Some(vec_set_qid) = env.vec_set_qid() {
-            let vec_set_tys = info
-                .structs
-                .get(&vec_set_qid)
-                .map_or_else(BTreeSet::new, |set| set.clone());
-
-            // VecSet<T> uses vec<T> internally, so we need to add T to vec_inst
-            for tys in &vec_set_tys {
-                if !tys.is_empty() {
-                    info.vec_inst.extend(tys.iter().cloned());
-                }
-            }
-
-            info.structs
-                .entry(env.option_qid().unwrap())
-                .or_default()
-                .extend(vec_set_tys);
-
-            // VecSet also uses vec<u64> internally for storing indices, so we need to add u64 to vec_inst
-            let has_vec_set = info
-                .structs
-                .get(&vec_set_qid)
-                .map_or(false, |set| !set.is_empty());
-
-            if has_vec_set {
-                info.vec_inst
-                    .insert(Type::Primitive(move_model::ty::PrimitiveType::U64));
-
-                info.structs
-                    .entry(env.option_qid().unwrap())
-                    .or_default()
-                    .insert(vec![Type::Primitive(move_model::ty::PrimitiveType::U64)]);
-            }
-        }
-        if let Some(vec_map_qid) = env.vec_map_qid() {
-            let vec_map_tys = info
-                .structs
-                .get(&vec_map_qid)
-                .map_or_else(BTreeSet::new, |set| set.clone());
-
-            // VecMap<K, V> uses vec<K> internally, so we need to add K to vec_inst
-            for tys in &vec_map_tys {
-                info.vec_inst.extend(tys.iter().cloned());
-            }
-
-            // Also add the key type to Option instantiations
-            let vec_map_option_tys = vec_map_tys
-                .into_iter()
-                .flat_map(|tys| tys.into_iter().map(|ty| vec![ty]));
-            info.structs
-                .entry(env.option_qid().unwrap())
-                .or_default()
-                .extend(vec_map_option_tys);
-
-            // VecMap also uses vec<u64> internally for storing indices, so we need to add u64 to vec_inst
-            let has_vec_map = info
-                .structs
-                .get(&vec_map_qid)
-                .map_or(false, |set| !set.is_empty());
-
-            if has_vec_map {
-                info.vec_inst
-                    .insert(Type::Primitive(move_model::ty::PrimitiveType::U64));
-
-                info.structs
-                    .entry(env.option_qid().unwrap())
-                    .or_default()
-                    .insert(vec![Type::Primitive(move_model::ty::PrimitiveType::U64)]);
-            }
-        }
-
-        // Add bool instantiation by default for dynamic fields
-        info.vec_inst
-            .insert(Type::Primitive(move_model::ty::PrimitiveType::Bool));
-        info.structs
-            .entry(env.option_qid().unwrap())
-            .or_default()
-            .insert(vec![Type::Primitive(move_model::ty::PrimitiveType::Bool)]);
-
-        // Add ID generation by default
-        if let Some(id_qid) = env.id_qid() {
-            info.structs.entry(id_qid).or_default().insert(vec![]);
-        }
-
-        if let Some(uid_qid) = env.uid_qid() {
-            info.structs.entry(uid_qid).or_default().insert(vec![]);
-        }
 
         env.set_extension(info);
     }
@@ -711,6 +690,16 @@ impl Analyzer<'_> {
 
     // Utility functions
     // -----------------
+
+    fn add_option_type(&mut self, inner_ty: &Type) {
+        self.info.vec_inst.insert(inner_ty.clone());
+        let option_qid = self.env.option_qid().unwrap();
+        self.add_type_root(&Type::Datatype(
+            option_qid.module_id,
+            option_qid.id,
+            vec![inner_ty.clone()],
+        ));
+    }
 
     fn add_types_in_borrow_edge(&mut self, edge: &BorrowEdge) {
         match edge {

--- a/crates/sui-prover/tests/inputs/issue-299.move
+++ b/crates/sui-prover/tests/inputs/issue-299.move
@@ -1,0 +1,33 @@
+module 0x42::A {
+    use std::option::some;
+    fun foo(x: Option<u8>): Option<u8> {
+        if (x.is_some()) {
+            x
+        } else {
+            some(0)
+        }
+    }
+
+    #[spec(prove)]
+    fun foo_spec(x: Option<u8>): Option<u8> {
+        foo(x)
+    }
+}
+
+module 0x42::B {
+    use std::option::some;
+    use prover::prover::{val, drop};
+
+    #[spec_only(inv_target=std::option::Option)]
+    fun Option_inv<T>(self: &Option<T>): bool {
+        if (self.is_some()) {
+            let o = val(self.borrow());
+            let x = some(o);
+            let b = self == x;
+            drop(x);
+            b
+        } else {
+            true
+        }
+    }
+}

--- a/crates/sui-prover/tests/snapshots/issue-299.move.snap
+++ b/crates/sui-prover/tests/snapshots/issue-299.move.snap
@@ -1,0 +1,6 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 260
+expression: output
+---
+Verification successful


### PR DESCRIPTION
Fixes #299.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `Option` and `vector` instantiations are recorded for dynamic fields, `VecSet<T>`, and `VecMap<K,V>` (including `u64` indices), and add a regression test that verifies success (issue-299).
> 
> - **Mono analysis (`crates/move-stackless-bytecode/src/mono_analysis.rs`)**:
>   - Add utility `add_option_type` and use it to register `Option<T>` and corresponding `vector<T>` instantiations.
>   - Update handling of dynamic fields to add `Option<value>` and root types for `name`/`value`.
>   - For `VecSet<T>`: add `vector<T>` and root `T`; add `Option<u64>` for internal indices.
>   - For `VecMap<K,V>`: add `vector<K>` and `vector<V>`; add root `K` and `Option<V>`; add `Option<u64>` for indices.
>   - Add ID/UID via `add_type_root`; set `info.all_types` after analysis.
> - **Tests**:
>   - Add `crates/sui-prover/tests/inputs/issue-299.move` and snapshot asserting "Verification successful".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec77f3317bd76da9a734ad60778b632b0d84b62a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->