### PR TITLE
fix wip for CI

### DIFF
--- a/crates/move-prover-lean-backend/src/lean_backend/mod.rs
+++ b/crates/move-prover-lean-backend/src/lean_backend/mod.rs
@@ -8,6 +8,6 @@ pub mod lean_helpers;
 #[macro_export]
 macro_rules! wip {
     ($name:expr) => {
-        println!("WIP: {}", $name);
+        println!("WIP: {}", $name)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the trailing semicolon from the `wip!` macro’s `println!` in `lean_backend/mod.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a81beaee371d6d0a3f1916509fd894d131597fdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->