### PR TITLE
Add generating bpl for Ika into CI

### DIFF
--- a/.github/workflows/sui-prover.yml
+++ b/.github/workflows/sui-prover.yml
@@ -367,7 +367,7 @@ jobs:
     runs-on: macos-latest
 
     concurrency:
-      group: scallop-bpl-generation-${{ github.head_ref || github.ref_name }}
+      group: ika-bpl-generation-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
 
     steps:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new CI job to generate Boogie BPL for Ika specs using the built sui-prover bundle.
> 
> - **CI (GitHub Actions)**:
>   - **New job `ika-bpl-generation` in `.github/workflows/sui-prover.yml`**:
>     - Downloads the prover artifact bundle from `build-prover` and sets up `sui-prover`, `boogie`, and `z3` environment.
>     - Checks out `asymptotic-code/ika-fv@specs` to `ika/`.
>     - Runs `sui-prover -g --ci` in `ika/contracts/specs` to generate BPL.
>     - Configured concurrency group `ika-bpl-generation-${{ github.head_ref || github.ref_name }}` with cancel-in-progress.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 294db02b7e2660f95b9deaf8300c96a7b1db5bc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->