### PR TITLE
full ssa support for candidate functions (eliminate var reuse)

### DIFF
--- a/crates/move-stackless-bytecode/src/conditional_merge_insertion.rs
+++ b/crates/move-stackless-bytecode/src/conditional_merge_insertion.rs
@@ -26,7 +26,7 @@ use crate::{
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     graph::Graph,
     livevar_analysis::LiveVarAnnotation,
-    stackless_bytecode::{AssignKind, AttrId, Bytecode, Label, Operation},
+    stackless_bytecode::{AttrId, Bytecode, Label, Operation},
     stackless_control_flow_graph::{BlockId, StacklessControlFlowGraph},
 };
 use move_compiler::shared::known_attributes::AttributeKind_;
@@ -406,13 +406,6 @@ impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
                                 )
                             });
 
-                            builder.set_next_debug_comment(format!(
-                                "conditional_merge_insertion: merge assign t{} := t{}",
-                                ins.dest_var, new_temp
-                            ));
-                            builder.emit_with(|id| {
-                                Bytecode::Assign(id, ins.dest_var, new_temp, AssignKind::Store)
-                            });
                             current_val.insert(ins.dest_var, new_temp);
                         }
                     }
@@ -473,8 +466,10 @@ impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
                         .get(&original_dst)
                         .copied()
                         .unwrap_or(original_dst);
-                    current_val.insert(original_dst, src); // Track latest rhs value of original dst
-                    builder.emit(Bytecode::Assign(attr, fresh_dst, src, kind))
+                    // Remap source operand through current_val to use SSA variable
+                    let remapped_src = current_val.get(&src).copied().unwrap_or(src);
+                    current_val.insert(original_dst, remapped_src); // Track latest rhs value of original dst
+                    builder.emit(Bytecode::Assign(attr, fresh_dst, remapped_src, kind))
                 }
                 Bytecode::Call(attr, dests, op, srcs, abort) if dests.len() == 1 => {
                     let original_dest = dests[0];
@@ -482,8 +477,39 @@ impl FunctionTargetProcessor for ConditionalMergeInsertionProcessor {
                         .get(&original_dest)
                         .copied()
                         .unwrap_or(original_dest);
-                    current_val.insert(original_dest, original_dest);
-                    builder.emit(Bytecode::Call(attr, vec![actual_dest], op, srcs, abort))
+                    // Remap source operands through current_val to use SSA variables
+                    let remapped_srcs: Vec<usize> = srcs
+                        .iter()
+                        .map(|&s| current_val.get(&s).copied().unwrap_or(s))
+                        .collect();
+                    current_val.insert(original_dest, actual_dest);
+                    builder.emit(Bytecode::Call(
+                        attr,
+                        vec![actual_dest],
+                        op,
+                        remapped_srcs,
+                        abort,
+                    ))
+                }
+                Bytecode::Call(attr, dests, op, srcs, abort) if dests.is_empty() => {
+                    // Handle calls with no destinations (e.g., TraceReturn, TraceLocal, TraceAbort)
+                    // Remap source operands through current_val to use SSA variables
+                    let remapped_srcs: Vec<usize> = srcs
+                        .iter()
+                        .map(|&s| current_val.get(&s).copied().unwrap_or(s))
+                        .collect();
+                    builder.emit(Bytecode::Call(attr, dests, op, remapped_srcs, abort))
+                }
+                Bytecode::Ret(attr, srcs) => {
+                    let remapped_srcs = srcs
+                        .iter()
+                        .map(|&s| current_val.get(&s).copied().unwrap_or(s))
+                        .collect();
+                    builder.emit(Bytecode::Ret(attr, remapped_srcs))
+                }
+                Bytecode::Abort(attr, src) => {
+                    let remapped_src = current_val.get(&src).copied().unwrap_or(src);
+                    builder.emit(Bytecode::Abort(attr, remapped_src))
                 }
                 bytecode => builder.emit(bytecode),
             }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/01_simple_if_conditional.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/01_simple_if_conditional.snap
@@ -53,7 +53,5 @@ public fun test::f($t0|a: u64): u64 {
   8: label L0
      # conditional_merge_insertion: t7 := if_then_else(t4, t6, t2)
   9: $t7 := if_then_else($t4, $t6, $t2)
-     # conditional_merge_insertion: merge assign t1 := t7
- 10: $t1 := $t7
- 11: return $t1
+ 10: return $t7
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/02_consecutive_if_conditionals.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/02_consecutive_if_conditionals.snap
@@ -97,29 +97,23 @@ public fun test::f($t0|a: u64): u64 {
   8: label L0
      # conditional_merge_insertion: t13 := if_then_else(t4, t12, t2)
   9: $t13 := if_then_else($t4, $t12, $t2)
-     # conditional_merge_insertion: merge assign t1 := t13
- 10: $t1 := $t13
- 11: $t6 := 5
- 12: $t7 := >($t0, $t6)
- 13: if ($t7) goto 14 else goto 17
- 14: label L3
- 15: $t8 := 20
- 16: $t14 := *($t1, $t8)
- 17: label L2
+ 10: $t6 := 5
+ 11: $t7 := >($t0, $t6)
+ 12: if ($t7) goto 13 else goto 16
+ 13: label L3
+ 14: $t8 := 20
+ 15: $t14 := *($t13, $t8)
+ 16: label L2
      # conditional_merge_insertion: t15 := if_then_else(t7, t14, t13)
- 18: $t15 := if_then_else($t7, $t14, $t13)
-     # conditional_merge_insertion: merge assign t1 := t15
- 19: $t1 := $t15
- 20: $t9 := 10
- 21: $t10 := >($t0, $t9)
- 22: if ($t10) goto 23 else goto 26
- 23: label L5
- 24: $t11 := 30
- 25: $t16 := *($t1, $t11)
- 26: label L4
+ 17: $t15 := if_then_else($t7, $t14, $t13)
+ 18: $t9 := 10
+ 19: $t10 := >($t0, $t9)
+ 20: if ($t10) goto 21 else goto 24
+ 21: label L5
+ 22: $t11 := 30
+ 23: $t16 := *($t15, $t11)
+ 24: label L4
      # conditional_merge_insertion: t17 := if_then_else(t10, t16, t15)
- 27: $t17 := if_then_else($t10, $t16, $t15)
-     # conditional_merge_insertion: merge assign t1 := t17
- 28: $t1 := $t17
- 29: return $t1
+ 25: $t17 := if_then_else($t10, $t16, $t15)
+ 26: return $t17
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/03_multiple_assignments_in_then.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/03_multiple_assignments_in_then.snap
@@ -51,7 +51,5 @@ fun ConditionalMergeInsertionTest::multiple_assignments_in_then($t0|cond: bool, 
   7: label L0
      # conditional_merge_insertion: t7 := if_then_else(t0, t6, t1)
   8: $t7 := if_then_else($t0, $t6, $t1)
-     # conditional_merge_insertion: merge assign t2 := t7
-  9: $t2 := $t7
- 10: return $t2
+  9: return $t7
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/04_if_then_else_with_assignments.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/04_if_then_else_with_assignments.snap
@@ -112,18 +112,14 @@ fun ConditionalMergeInsertionTest::if_then_else_with_assignments($t0|cond: bool,
  12: label L2
      # conditional_merge_insertion: t14 := if_then_else(t7, t12, t13)
  13: $t14 := if_then_else($t7, $t12, $t13)
-     # conditional_merge_insertion: merge assign t2 := t14
- 14: $t2 := $t14
- 15: $t3 := $t2
- 16: if ($t0) goto 17 else goto 21
- 17: label L4
- 18: $t10 := 38992368544603139932233054999993551
- 19: $t11 := 96
- 20: $t15 := ConditionalMergeInsertionTest::helper_function($t2, $t10, $t11)
- 21: label L3
-     # conditional_merge_insertion: t16 := if_then_else(t0, t15, t2)
- 22: $t16 := if_then_else($t0, $t15, $t2)
-     # conditional_merge_insertion: merge assign t3 := t16
- 23: $t3 := $t16
- 24: return $t3
+ 14: $t3 := $t14
+ 15: if ($t0) goto 16 else goto 20
+ 16: label L4
+ 17: $t10 := 38992368544603139932233054999993551
+ 18: $t11 := 96
+ 19: $t15 := ConditionalMergeInsertionTest::helper_function($t14, $t10, $t11)
+ 20: label L3
+     # conditional_merge_insertion: t16 := if_then_else(t0, t15, t14)
+ 21: $t16 := if_then_else($t0, $t15, $t14)
+ 22: return $t16
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/05_if_then_multi_variables.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/05_if_then_multi_variables.snap
@@ -70,12 +70,8 @@ public fun test::f($t0|a: u64): u64 {
  12: label L0
      # conditional_merge_insertion: t12 := if_then_else(t6, t10, t3)
  13: $t12 := if_then_else($t6, $t10, $t3)
-     # conditional_merge_insertion: merge assign t1 := t12
- 14: $t1 := $t12
      # conditional_merge_insertion: t13 := if_then_else(t6, t11, t4)
- 15: $t13 := if_then_else($t6, $t11, $t4)
-     # conditional_merge_insertion: merge assign t2 := t13
- 16: $t2 := $t13
- 17: $t9 := *($t1, $t2)
- 18: return $t9
+ 14: $t13 := if_then_else($t6, $t11, $t4)
+ 15: $t9 := *($t12, $t13)
+ 16: return $t9
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/06_if_then_else_symmetric_multi_variables.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/06_if_then_else_symmetric_multi_variables.snap
@@ -76,12 +76,8 @@ public fun test::f($t0|a: u64): u64 {
  14: label L2
      # conditional_merge_insertion: t14 := if_then_else(t4, t10, t11)
  15: $t14 := if_then_else($t4, $t10, $t11)
-     # conditional_merge_insertion: merge assign t1 := t14
- 16: $t1 := $t14
      # conditional_merge_insertion: t15 := if_then_else(t4, t12, t13)
- 17: $t15 := if_then_else($t4, $t12, $t13)
-     # conditional_merge_insertion: merge assign t2 := t15
- 18: $t2 := $t15
- 19: $t9 := *($t1, $t2)
- 20: return $t9
+ 16: $t15 := if_then_else($t4, $t12, $t13)
+ 17: $t9 := *($t14, $t15)
+ 18: return $t9
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/07_if_then_else_assymetric.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/07_if_then_else_assymetric.snap
@@ -75,12 +75,8 @@ public fun test::f($t0|a: u64): u64 {
  14: label L2
      # conditional_merge_insertion: t13 := if_then_else(t5, t3, t10)
  15: $t13 := if_then_else($t5, $t3, $t10)
-     # conditional_merge_insertion: merge assign t1 := t13
- 16: $t1 := $t13
      # conditional_merge_insertion: t14 := if_then_else(t5, t11, t12)
- 17: $t14 := if_then_else($t5, $t11, $t12)
-     # conditional_merge_insertion: merge assign t2 := t14
- 18: $t2 := $t14
- 19: $t9 := *($t1, $t2)
- 20: return $t9
+ 16: $t14 := if_then_else($t5, $t11, $t12)
+ 17: $t9 := *($t13, $t14)
+ 18: return $t9
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/08_asymmetric_multi_variables.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/08_asymmetric_multi_variables.snap
@@ -66,12 +66,8 @@ public fun test::f($t0|cond: bool): u64 {
  12: label L2
      # conditional_merge_insertion: t10 := if_then_else(t0, t8, t3)
  13: $t10 := if_then_else($t0, $t8, $t3)
-     # conditional_merge_insertion: merge assign t1 := t10
- 14: $t1 := $t10
      # conditional_merge_insertion: t11 := if_then_else(t0, t4, t9)
- 15: $t11 := if_then_else($t0, $t4, $t9)
-     # conditional_merge_insertion: merge assign t2 := t11
- 16: $t2 := $t11
- 17: $t7 := *($t1, $t2)
- 18: return $t7
+ 14: $t11 := if_then_else($t0, $t4, $t9)
+ 15: $t7 := *($t10, $t11)
+ 16: return $t7
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/09_early_ret.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/09_early_ret.snap
@@ -77,17 +77,13 @@ public fun test::f($t0|cond: bool): u64 {
  12: label L2
      # conditional_merge_insertion: t11 := if_then_else(t0, t9, t3)
  13: $t11 := if_then_else($t0, $t9, $t3)
-     # conditional_merge_insertion: merge assign t1 := t11
- 14: $t1 := $t11
      # conditional_merge_insertion: t12 := if_then_else(t0, t4, t10)
- 15: $t12 := if_then_else($t0, $t4, $t10)
-     # conditional_merge_insertion: merge assign t2 := t12
- 16: $t2 := $t12
- 17: $t7 := !($t0)
- 18: if ($t7) goto 19 else goto 21
- 19: label L4
- 20: return $t2
- 21: label L3
- 22: $t8 := *($t1, $t2)
- 23: return $t8
+ 14: $t12 := if_then_else($t0, $t4, $t10)
+ 15: $t7 := !($t0)
+ 16: if ($t7) goto 17 else goto 19
+ 17: label L4
+ 18: return $t12
+ 19: label L3
+ 20: $t8 := *($t11, $t12)
+ 21: return $t8
 }

--- a/crates/move-stackless-bytecode/tests/conditional_merge_insertion/10_with_function_calls.snap
+++ b/crates/move-stackless-bytecode/tests/conditional_merge_insertion/10_with_function_calls.snap
@@ -104,14 +104,10 @@ public fun test::f($t0|a: u32): u64 {
  16: label L0
      # conditional_merge_insertion: t16 := if_then_else(t8, t14, t3)
  17: $t16 := if_then_else($t8, $t14, $t3)
-     # conditional_merge_insertion: merge assign t1 := t16
- 18: $t1 := $t16
      # conditional_merge_insertion: t17 := if_then_else(t8, t15, t4)
- 19: $t17 := if_then_else($t8, $t15, $t4)
-     # conditional_merge_insertion: merge assign t2 := t17
- 20: $t2 := $t17
- 21: $t13 := *($t1, $t2)
- 22: return $t13
+ 18: $t17 := if_then_else($t8, $t15, $t4)
+ 19: $t13 := *($t16, $t17)
+ 20: return $t13
 }
 
 


### PR DESCRIPTION
stacked on https://github.com/asymptotic-code/sui-prover/pull/320

Eliminates var reuse at merge points, giving a full ssa representation for candidate functions

#311 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates post-merge reassignments and remaps all operands to SSA across assigns/calls/ret/abort (incl. no-dest calls), updating snapshots accordingly.
> 
> - **Conditional merge insertion (`conditional_merge_insertion.rs`)**:
>   - Remove post-merge variable reassignments; use the `if_then_else` temp directly (no `merge assign`).
>   - Remap sources to SSA in `Assign`, `Call` (single dest), `Call` with no dest, `Ret`, and `Abort` using `current_val`.
>   - Track fresh vars per branch via labels; update `current_val` to reflect SSA temps.
>   - Clean up imports (drop `AssignKind` usage) and debug comments for merge assigns.
> - **Tests (snapshots)**:
>   - Update expected bytecode to return/use `if_then_else` temps directly and propagate SSA vars through subsequent operations.
>   - Adjust usages after conditionals to reference SSA temps instead of reassigned locals across all cases (simple, multi-var, early return, with calls).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b212fa22f00f0c67b49c1eced9c868a5feb09622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->