### PR TITLE
Fix generic case not being handled in translation and integration tests on Windows 

### DIFF
--- a/crates/move-stackless-bytecode/src/stackless_bytecode_generator.rs
+++ b/crates/move-stackless-bytecode/src/stackless_bytecode_generator.rs
@@ -1452,12 +1452,15 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                     MoveBytecode::UnpackVariantImmRef(_) => Type::Reference(false, Box::new(ty)),
                     MoveBytecode::UnpackVariantMutRef(_) => Type::Reference(true, Box::new(ty)),
                     MoveBytecode::UnpackVariant(_) => ty,
+                    MoveBytecode::UnpackVariantGenericImmRef(_) => Type::Reference(false, Box::new(ty)),
+                    MoveBytecode::UnpackVariantGenericMutRef(_) => Type::Reference(true, Box::new(ty)),
+                    MoveBytecode::UnpackVariantGeneric(_) => ty,
                     _ => unreachable!(),
                 };
                 let ref_type = match bytecode {
-                    MoveBytecode::UnpackVariant(_) => RefType::ByValue,
-                    MoveBytecode::UnpackVariantImmRef(_) => RefType::ByImmRef,
-                    MoveBytecode::UnpackVariantMutRef(_) => RefType::ByMutRef,
+                    MoveBytecode::UnpackVariant(_) | MoveBytecode::UnpackVariantGeneric(_) => RefType::ByValue,
+                    MoveBytecode::UnpackVariantImmRef(_) | MoveBytecode::UnpackVariantGenericImmRef(_) => RefType::ByImmRef,
+                    MoveBytecode::UnpackVariantMutRef(_) | MoveBytecode::UnpackVariantGenericMutRef(_) => RefType::ByMutRef,
                     _ => unreachable!(),
                 };
                 let variant_temp_index = self.temp_stack.pop().unwrap();

--- a/crates/sui-prover/tests/integration.rs
+++ b/crates/sui-prover/tests/integration.rs
@@ -21,7 +21,7 @@ fn run_prover(file_path: &Path) -> String {
         .unwrap()
         .join("packages")
         .join("sui-prover");
-    let prover_dir_dis = prover_dir.display();
+    let prover_dir_dis = prover_dir.display().to_string().replace('\\', "/");
     let tmp = tempfile::tempdir().unwrap();
     let tmp_dir = tmp.path();
     std::fs::write(


### PR DESCRIPTION
A change in one of the Sui dependencies has started hitting an old bug with the stackless translation, where only the non-generic case of an instruction is handled. This simply adds the generic case to that check as well.

Also, adds a replace to catch windows path separators in the integration code and replace them with Unix path separators (to fix an error with manifest parsing on Windows).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add support for `UnpackVariantGeneric*` enum unpack instructions in the stackless bytecode generator and normalize Windows paths in integration tests.
> 
> - **Stackless Bytecode Generator (`crates/move-stackless-bytecode/src/stackless_bytecode_generator.rs`)**:
>   - Handle generic enum unpack instructions: `UnpackVariantGeneric`, `UnpackVariantGenericImmRef`, `UnpackVariantGenericMutRef`.
>   - Compute correct unpacked field types and `RefType` for generic and reference variants.
> - **Integration Tests (`crates/sui-prover/tests/integration.rs`)**:
>   - Normalize Windows path separators by replacing `\\` with `/` in `prover_dir` for manifest parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d66b358322a008da646d5b0092a7e0485005f544. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->