### PR TITLE
Delete return jumps.

### DIFF
--- a/crates/sui-prover/tests/snapshots/conditionals/simple_max.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/conditionals/simple_max.fail.move.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 271
 expression: output
 ---
 exiting with verification errors
@@ -83,12 +82,7 @@ L2:
     // trace_return[0]($t6) at tests/inputs/conditionals/simple_max.fail.move:9:5+144
     assume {:print "$track_return(118,0,0,u64):", $t6} $t6 == $t6;
 
-    // label L3 at tests/inputs/conditionals/simple_max.fail.move:14:1+1
-    assume {:print "$at(120,376,377)"} true;
-L3:
-
-    // return $t6 at tests/inputs/conditionals/simple_max.fail.move:14:1+1
-    assume {:print "$at(120,376,377)"} true;
+    // return $t6 at tests/inputs/conditionals/simple_max.fail.move:9:5+144
     $ret0 := $t6;
     return;
 

--- a/crates/sui-prover/tests/snapshots/conditionals/simple_max.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/conditionals/simple_max.ok.move.snap
@@ -66,12 +66,7 @@ L2:
     // trace_return[0]($t6) at tests/inputs/conditionals/simple_max.ok.move:8:5+52
     assume {:print "$track_return(118,0,0,u64):", $t6} $t6 == $t6;
 
-    // label L3 at tests/inputs/conditionals/simple_max.ok.move:13:1+1
-    assume {:print "$at(120,200,201)"} true;
-L3:
-
-    // return $t6 at tests/inputs/conditionals/simple_max.ok.move:13:1+1
-    assume {:print "$at(120,200,201)"} true;
+    // return $t6 at tests/inputs/conditionals/simple_max.ok.move:8:5+52
     $ret0 := $t6;
     return;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the unified return jump/label machinery so `Ret` is emitted directly, adjusts spec translation accordingly, and updates snapshots to match direct returns.
> 
> - **Spec Instrumentation**:
>   - Remove unified return locals/label and the generated return block; `Ret(..)` is now emitted unchanged.
>   - Stop passing `ret_locals` to `SpecTranslator::translate_fun_spec` (use empty list).
>   - Drop import of `Label`.
> - **Tests/Snapshots**:
>   - Update conditional examples to return directly at the original site (no extra label block), with adjusted source annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99889ec5aec773f404372686ee814a0c828db245. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->