### PR TITLE
fix: skip messages

### DIFF
--- a/crates/move-stackless-bytecode/src/package_targets.rs
+++ b/crates/move-stackless-bytecode/src/package_targets.rs
@@ -390,6 +390,13 @@ impl PackageTargets {
                 self.ignore_aborts.insert(func_env.get_qualified_id());
             }
 
+            if let Some(skip_reason) = skip {
+                if filter.is_targeted(func_env) {
+                    self.skipped_specs
+                        .insert(func_env.get_qualified_id(), skip_reason.clone());
+                }
+            }
+
             if !func_env.module_env.is_target()
                 || skip.is_some()
                 || !filter.is_targeted(func_env)


### PR DESCRIPTION
returns `:black_right_pointing_double_triangle_with_vertical_bar: <spec name>` for specs with skip attribute