### PR TITLE
Add pure Pack.

### DIFF
--- a/crates/sui-prover/tests/snapshots/multiple_specs/include_external.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/multiple_specs/include_external.fail.move.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/sui-prover/tests/integration.rs
+assertion_line: 267
 expression: output
 ---
 [internal] boogie exited with compilation errors:
-output/multiple_specs/include_external.fail/bar_specs_double_foo_imported_module::bar_spec_Assume.bpl(4446,4): Error: call to undeclared procedure: $42_fb_foo
+output/multiple_specs/include_external.fail/bar_specs_double_foo_imported_module::bar_spec_Assume.bpl(4478,4): Error: call to undeclared procedure: $42_fb_foo
 1 name resolution errors detected in output/multiple_specs/include_external.fail/bar_specs_double_foo_imported_module::bar_spec_Assume.bpl


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements Boogie translation for `Pack` (including dynamic fields) in pure/regular paths and strips `log::*` calls from `#[ext(pure)]` functions with warnings; minor error handling tightened and snapshots updated.
> 
> - **Boogie backend**:
>   - **Pure translation**: Support `Operation::Pack` in `generate_pure_expression`, constructing structs and auto-initializing dynamic fields with `EmptyTable()`.
>   - **Regular translation**: `Pack` now also initializes dynamic fields with `EmptyTable()`.
>   - **Stricter handling**: Replace silent fallthroughs with `unreachable!/panic!` and add clearer arity/error messages in pure op formatting.
> - **Debug instrumentation**:
>   - Detect `#[ext(pure)]` functions, drop `log_text/log_var/log_ghost` calls and emit warnings; skip trace instrumentation for these.
> - **Tests**:
>   - Update snapshot line/diagnostic locations in `multiple_specs/include_external.fail.move.snap`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9ff19d9430b3b06d5a3c77ad9fdd026b7c16983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->