### PR TITLE
Fix `--stats` filtering

### DIFF
--- a/crates/move-stackless-bytecode/src/function_stats.rs
+++ b/crates/move-stackless-bytecode/src/function_stats.rs
@@ -59,7 +59,11 @@ fn should_include_function(func_env: &FunctionEnv, targets: &PackageTargets) -> 
     if func_env.visibility() != Visibility::Public && !func_env.is_entry() {
         return false;
     }
-    if has_attribute(func_env, "spec_only") {
+    if func_env
+        .get_toplevel_attributes()
+        .get_(&AttributeKind_::SpecOnly)
+        .is_some()
+    {
         return false;
     }
     if has_attribute(func_env, "test_only") {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust which functions are counted/shown in the stats output and tweak attribute checks, with no runtime or on-chain behavior impact.
> 
> **Overview**
> The `--stats` function statistics output now includes *entry* functions even when they are not `public`, and updates the summary/counting language to reflect “public/entry” functions.
> 
> Filtering was tightened by detecting `spec_only` via `AttributeKind_::SpecOnly` (instead of name matching), while still excluding `test_only`, spec functions, and mode-marked functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc08c4139893acb7eb1fd59a15eb92dd488ddba7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->