### PR TITLE
Split SpecNoAssertsCheck in separate file.

### DIFF
--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -91,6 +91,7 @@ pub struct BoogieTranslator<'env> {
 pub enum AssertsMode {
     Check,
     Assume,
+    SpecNoAbortCheck,
 }
 
 pub struct FunctionTranslator<'env> {
@@ -562,7 +563,7 @@ impl<'env> BoogieTranslator<'env> {
                     &FunctionVariant::Verification(VerificationFlavor::Regular),
                 );
                 let do_verify = match self.asserts_mode {
-                    AssertsMode::Check => !self
+                    AssertsMode::Check | AssertsMode::SpecNoAbortCheck => !self
                         .targets
                         .ignore_aborts()
                         .contains(&fun_env.get_qualified_id()),
@@ -601,6 +602,9 @@ impl<'env> BoogieTranslator<'env> {
 
         match self.asserts_mode {
             AssertsMode::Check => {
+                if style == FunctionTranslationStyle::SpecNoAbortCheck {
+                    return;
+                }
                 if style.is_asserts_style() {
                     return;
                 }
@@ -637,6 +641,16 @@ impl<'env> BoogieTranslator<'env> {
                         .iter()
                         .any(|f| *f == self.env.asserts_qid())
                 {
+                    return;
+                }
+            }
+            AssertsMode::SpecNoAbortCheck => {
+                if FunctionTranslationStyle::Default == style
+                    && self.targets.is_verified_spec(&fun_env.get_qualified_id())
+                {
+                    return;
+                }
+                if style.is_asserts_style() {
                     return;
                 }
             }
@@ -944,11 +958,15 @@ impl<'env> BoogieTranslator<'env> {
         }
 
         let mut data = builder.data;
-        let reach_def = ReachingDefProcessor::new();
-        let live_vars = LiveVarAnalysisProcessor::new_with_options(false, false);
         let mut dummy_targets = self.targets.new_dummy();
-        data = reach_def.process(&mut dummy_targets, builder.fun_env, data, None);
-        data = live_vars.process(&mut dummy_targets, builder.fun_env, data, None);
+        if data.code.len() > 0 {
+            let reach_def = ReachingDefProcessor::new();
+            data = reach_def.process(&mut dummy_targets, builder.fun_env, data, None);
+        }
+        if data.code.len() > 0 {
+            let live_vars = LiveVarAnalysisProcessor::new_with_options(false, false);
+            data = live_vars.process(&mut dummy_targets, builder.fun_env, data, None);
+        }
 
         let fun_target = FunctionTarget::new(builder.fun_env, &data);
         if matches!(style, FunctionTranslationStyle::Pure) {
@@ -2526,12 +2544,14 @@ impl<'env> FunctionTranslator<'env> {
         if emit_pure_in_place {
             self.generate_pure_expression(code);
         } else {
-            // Use CFG recovery to generate structured if-then-else statements
-            match control_flow_reconstruction::reconstruct_control_flow(code) {
-                Some(block) => self.translate_structured_block(&mut last_tracked_loc, &block),
-                None => {
-                    for bytecode in code {
-                        self.translate_bytecode(&mut last_tracked_loc, bytecode);
+            if code.len() > 0 {
+                // Use CFG recovery to generate structured if-then-else statements
+                match control_flow_reconstruction::reconstruct_control_flow(code) {
+                    Some(block) => self.translate_structured_block(&mut last_tracked_loc, &block),
+                    None => {
+                        for bytecode in code {
+                            self.translate_bytecode(&mut last_tracked_loc, bytecode);
+                        }
                     }
                 }
             }
@@ -3514,7 +3534,7 @@ impl<'env> FunctionTranslator<'env> {
             }
             Ret(_, rets) => {
                 match self.parent.asserts_mode {
-                    AssertsMode::Check => {
+                    AssertsMode::Check | AssertsMode::SpecNoAbortCheck => {
                         if FunctionTranslationStyle::Opaque == self.style
                             && !self
                                 .parent
@@ -5467,7 +5487,7 @@ impl<'env> FunctionTranslator<'env> {
                 }
                 match aa {
                     Some(AbortAction::Check) => match self.parent.asserts_mode {
-                        AssertsMode::Check => {
+                        AssertsMode::Check | AssertsMode::SpecNoAbortCheck => {
                             let message = if self.parent.options.func_abort_check_only {
                                 "function code should not abort"
                             } else {
@@ -5489,7 +5509,7 @@ impl<'env> FunctionTranslator<'env> {
             }
             Abort(_, src) => {
                 match self.parent.asserts_mode {
-                    AssertsMode::Check => {
+                    AssertsMode::Check | AssertsMode::SpecNoAbortCheck => {
                         let message = if self.parent.options.func_abort_check_only {
                             "function code should not abort"
                         } else {

--- a/crates/move-prover-boogie-backend/src/generator.rs
+++ b/crates/move-prover-boogie-backend/src/generator.rs
@@ -173,7 +173,7 @@ async fn run_prover_spec_no_abort_check<W: WriteColor>(
                 error_writer,
                 targets,
                 mid,
-                AssertsMode::Check,
+                AssertsMode::SpecNoAbortCheck,
             )
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -512,6 +512,22 @@ pub async fn run_prover<W: WriteColor>(
                     })
                     .collect::<Result<Vec<_>, _>>()?,
             );
+            result.extend(
+                targets
+                    .target_specs()
+                    .iter()
+                    .map(|qid| {
+                        generate_function_bpl(
+                            env,
+                            options,
+                            error_writer,
+                            targets,
+                            qid,
+                            AssertsMode::SpecNoAbortCheck,
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
 
             result
         }
@@ -545,6 +561,22 @@ pub async fn run_prover<W: WriteColor>(
                             targets,
                             mid,
                             AssertsMode::Assume,
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+            result.extend(
+                targets
+                    .target_modules()
+                    .iter()
+                    .map(|mid| {
+                        generate_module_bpl(
+                            env,
+                            options,
+                            error_writer,
+                            targets,
+                            mid,
+                            AssertsMode::SpecNoAbortCheck,
                         )
                     })
                     .collect::<Result<Vec<_>, _>>()?,

--- a/crates/move-stackless-bytecode/src/stackless_control_flow_graph.rs
+++ b/crates/move-stackless-bytecode/src/stackless_control_flow_graph.rs
@@ -151,6 +151,7 @@ impl StacklessControlFlowGraph {
     }
 
     fn collect_blocks(code: &[Bytecode], ignore_return_abort: bool) -> Map<BlockId, Block> {
+        assert!(code.len() > 0);
         // First go through and collect basic block offsets.
         // Need to do this first in order to handle backwards edges.
         let label_offsets = Bytecode::label_offsets(code);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new prover generation/translation mode and runs it as an additional verification pass, which can change which specs/functions are emitted and how abort checks are enforced. Also tightens assumptions around empty bytecode/CFG handling, which may surface new panics or skip analysis in edge cases.
> 
> **Overview**
> Adds a new `AssertsMode::SpecNoAbortCheck` path and wires it through Boogie generation so the prover can emit/run an additional **spec no-abort check** pass (in both function and module file modes).
> 
> Updates bytecode translation to treat `SpecNoAbortCheck` like `Check` for abort assertions while skipping incompatible translation styles, and avoids running CFG reconstruction and dataflow analyses on empty bytecode (with an explicit non-empty assertion in CFG block collection).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2819290b758bbcc40b455906570031d6d048dcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->