### PR TITLE
Add native tx_context functions as pure functions.

### DIFF
--- a/crates/move-model/src/model.rs
+++ b/crates/move-model/src/model.rs
@@ -4031,6 +4031,12 @@ impl GlobalEnv {
             self.object_table_length_qid(),
             self.object_table_contains_qid(),
             self.object_borrow_uid_qid(),
+            // sui::tx_context native functions
+            self.sui_tx_context_sender_qid(),
+            self.sui_tx_context_epoch_qid(),
+            self.sui_tx_context_epoch_timestamp_ms_qid(),
+            self.sui_tx_context_reference_gas_price_qid(),
+            self.sui_tx_context_gas_price_qid(),
         ]
         .into_iter()
         .filter_map(|x| x)

--- a/crates/move-prover-boogie-backend/src/boogie_backend/prelude/prelude.bpl
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/prelude/prelude.bpl
@@ -221,6 +221,19 @@ function {:inline} $1_integer_div_real(x: int, y: int): real {
     x / y
 }
 
+// sui::tx_context native functions (uninterpreted)
+function $2_tx_context_native_sender(): int;
+function $2_tx_context_native_epoch(): int;
+function $2_tx_context_native_epoch_timestamp_ms(): int;
+function $2_tx_context_native_rgp(): int;
+function $2_tx_context_native_gas_price(): int;
+
+axiom $IsValid'address'($2_tx_context_native_sender());
+axiom $IsValid'u64'($2_tx_context_native_epoch());
+axiom $IsValid'u64'($2_tx_context_native_epoch_timestamp_ms());
+axiom $IsValid'u64'($2_tx_context_native_rgp());
+axiom $IsValid'u64'($2_tx_context_native_gas_price());
+
 function $to_u8(x: int): int {
     x mod 256
 }

--- a/crates/sui-prover/tests/snapshots/multiple_specs/include_external.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/multiple_specs/include_external.fail.move.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/sui-prover/tests/integration.rs
+assertion_line: 287
 expression: output
 ---
 [internal] boogie exited with compilation errors:
-output/multiple_specs/include_external.fail/bar_specs_double_foo_imported_module::bar_spec_Check.bpl(4350,4): Error: call to undeclared procedure: $42_fb_foo
+output/multiple_specs/include_external.fail/bar_specs_double_foo_imported_module::bar_spec_Check.bpl(4363,4): Error: call to undeclared procedure: $42_fb_foo
 1 name resolution errors detected in output/multiple_specs/include_external.fail/bar_specs_double_foo_imported_module::bar_spec_Check.bpl

--- a/packages/sui-specs/sources/sui-framework/tx_context.move
+++ b/packages/sui-specs/sources/sui-framework/tx_context.move
@@ -8,17 +8,13 @@ use sui::tx_context::{
     digest,
     epoch,
     epoch_timestamp_ms,
-    native_sender,
-    native_epoch,
-    native_epoch_timestamp_ms,
     fresh_id,
-    native_rgp,
     native_ids_created,
     native_gas_budget,
-    native_gas_price,
     last_created_id,
-    native_sponsor,
+    native_sponsor
 };
+
 #[spec_only]
 use prover::prover::{ensures, clone};
 
@@ -26,10 +22,7 @@ use prover::prover::{ensures, clone};
 fun fresh_object_address_spec(ctx: &mut TxContext): address {
     let old_ctx = clone!(ctx);
     let result = fresh_object_address(ctx);
-    // ensures(ctx.sender() == old_ctx.sender());
     ensures(ctx.digest() == old_ctx.digest());
-    // ensures(ctx.epoch() == old_ctx.epoch());
-    // ensures(ctx.epoch_timestamp_ms() == old_ctx.epoch_timestamp_ms());
     result
 }
 
@@ -38,34 +31,9 @@ fun derive_id_spec(tx_hash: vector<u8>, ids_created: u64): address {
     derive_id(tx_hash, ids_created)
 }
 
-#[spec(target = sui::tx_context::native_sender)]
-fun native_sender_spec(): address {
-    native_sender()
-}
-
-#[spec(target = sui::tx_context::native_epoch)]
-fun native_epoch_spec(): u64 {
-    native_epoch()
-}
-
-#[spec(target = sui::tx_context::native_epoch_timestamp_ms)]
-fun native_epoch_timestamp_ms_spec(): u64 {
-    native_epoch_timestamp_ms()
-}
-
 #[spec(target = sui::tx_context::fresh_id)]
 fun fresh_id_spec(): address {
     fresh_id()
-}
-
-#[spec(target = sui::tx_context::native_rgp)]
-fun native_rgp_spec(): u64 {
-    native_rgp()
-}
-
-#[spec(target = sui::tx_context::native_gas_price)]
-fun native_gas_price_spec(): u64 {
-    native_gas_price()
 }
 
 #[spec(target = sui::tx_context::native_ids_created)]


### PR DESCRIPTION
- Add native_sender, native_epoch, native_epoch_timestamp_ms, native_rgp, and native_gas_price to native_fn_ids() in model.rs
- Add corresponding uninterpreted Boogie function declarations in prelude.bpl
- Update bytecode_translator to not add $pure suffix for native functions that are in native_fn_ids(), as they use their base Boogie function name
- Remove redundant specs for these native functions from tx_context_spec

This allows these tx_context native functions to be used in pure function context without requiring $pure variant Boogie definitions.