### PR TITLE
fix: order of checking duplicates

### DIFF
--- a/crates/move-stackless-bytecode/src/function_target_pipeline.rs
+++ b/crates/move-stackless-bytecode/src/function_target_pipeline.rs
@@ -504,13 +504,13 @@ impl FunctionTargetsHolder {
         }
 
         if let Some(qid) = self.function_specs.get_by_right(&target_id) {
-            if self.package_targets.is_system_spec(qid) {
-            } else if self
-                .package_targets
-                .is_system_spec(&spec_env.get_qualified_id())
-            {
-                return;
-            } else {
+            if !self.package_targets.is_system_spec(qid) {
+                if self
+                    .package_targets
+                    .is_system_spec(&spec_env.get_qualified_id())
+                {
+                    return;
+                }
                 env.diag(
                     Severity::Error,
                     &spec_env.get_loc(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small conditional logic change affecting only duplicate-spec diagnostics; low blast radius but could alter which specs win/are accepted in edge cases.
> 
> **Overview**
> Updates `FunctionTargetsHolder::process_spec` duplicate-target handling to **early-return when the incoming spec is a system spec** and the existing mapping is non-system, instead of emitting a "Duplicate target function" error.
> 
> This changes the precedence/order of duplicate checks so system specs are effectively ignored in this conflict scenario, reducing spurious diagnostics when both system and non-system specs point at the same target function.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf8ae4f4e0877da3cf534b5ce6dc3e81e1a915f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->