### PR TITLE
Dump log files by default

### DIFF
--- a/crates/sui-prover/src/prove.rs
+++ b/crates/sui-prover/src/prove.rs
@@ -178,23 +178,22 @@ pub async fn execute(
     if general_config.stats {
         function_stats::display_function_stats(&model, &package_targets);
         return Ok(());
-    } else if general_config.dump_bytecode {
-        let mut options = move_prover_boogie_backend::generator_options::Options::default();
-        options.filter = filter.clone();
-        let (targets, _) = create_and_process_bytecode(
-            &options,
-            &model,
-            &package_targets,
-            FunctionHolderTarget::All,
-        );
-
-        let output_dir = std::path::Path::new(&options.output_path);
-        if !output_dir.exists() {
-            std::fs::create_dir_all(output_dir)?;
-        }
-
-        spec_hierarchy::display_spec_hierarchy(&model, &targets, output_dir);
     }
+
+    let mut options = move_prover_boogie_backend::generator_options::Options::default();
+    options.filter = filter.clone();
+    let (targets, _) = create_and_process_bytecode(
+        &options,
+        &model,
+        &package_targets,
+        FunctionHolderTarget::All,
+    );
+
+    let output_dir = std::path::Path::new(&options.output_path);
+    if !output_dir.exists() {
+        std::fs::create_dir_all(output_dir)?;
+    }
+    spec_hierarchy::display_spec_hierarchy(&model, &targets, output_dir);
 
     execute_backend_boogie(model, &general_config, remote_config, boogie_config, filter).await
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default prover behavior to always generate bytecode and create/write to an output directory, which can affect performance and produce unexpected filesystem artifacts in existing workflows/CI.
> 
> **Overview**
> The prover now **always generates and processes stackless bytecode and writes the spec hierarchy output** (creating the `options.output_path` directory as needed) during `execute`, rather than only doing this in the `--dump-bytecode` path.
> 
> `--stats` remains an early-return, but otherwise runs now have additional default filesystem output and bytecode-processing overhead before invoking the Boogie backend.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbf49bfd4ce08db476acf4e387b627245874ed74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->