### PR TITLE
Assume $IsValid for return values of uninterpreted functions (#523)

### DIFF
--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -4272,6 +4272,26 @@ impl<'env> FunctionTranslator<'env> {
                                 });
                         }
 
+                        // For uninterpreted functions, assume return values are valid
+                        // since Z3 has no information about the return type constraints.
+                        if self
+                            .parent
+                            .targets
+                            .is_uninterpreted(&callee_env.get_qualified_id())
+                        {
+                            for &dest in dests.iter() {
+                                let ty = self.get_local_type(dest);
+                                if !ty.is_mutable_reference() {
+                                    emitln!(
+                                        self.writer(),
+                                        "assume $IsValid'{}'({});",
+                                        boogie_type_suffix(env, &ty),
+                                        str_local(dest)
+                                    );
+                                }
+                            }
+                        }
+
                         // Clear the last track location after function call, as the call inserted
                         // location tracks before it returns.
                         *last_tracked_loc = None;

--- a/crates/sui-prover/tests/inputs/uninterpreted/isvalid_u8.ok.move
+++ b/crates/sui-prover/tests/inputs/uninterpreted/isvalid_u8.ok.move
@@ -1,0 +1,15 @@
+module 0x42::foo;
+
+#[ext(pure)]
+fun sub1(x: u8): u8 {
+    if (x > 0) x - 1 else 0
+}
+
+fun apply() {
+    assert!(sub1(1) <= 255, 1);
+}
+
+#[spec(prove, uninterpreted = sub1)]
+fun apply_spec() {
+    apply()
+}

--- a/crates/sui-prover/tests/inputs/uninterpreted/isvalid_vector.ok.move
+++ b/crates/sui-prover/tests/inputs/uninterpreted/isvalid_vector.ok.move
@@ -1,0 +1,16 @@
+module 0x42::foo;
+
+#[ext(pure)]
+fun vex(v: vector<u8>): vector<u8> {
+    v
+}
+
+fun user() {
+    let u = vector[1u8];
+    assert!(vex(u).length() >= 0, 1);
+}
+
+#[spec(prove, uninterpreted = vex)]
+fun user_spec() {
+    user();
+}

--- a/crates/sui-prover/tests/snapshots/uninterpreted/isvalid_u8.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/uninterpreted/isvalid_u8.ok.move.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-prover/tests/integration.rs
+expression: output
+---
+Verification successful

--- a/crates/sui-prover/tests/snapshots/uninterpreted/isvalid_vector.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/uninterpreted/isvalid_vector.ok.move.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-prover/tests/integration.rs
+expression: output
+---
+Verification successful


### PR DESCRIPTION
When a function is marked as uninterpreted, the prover generates a bodyless Boogie function. Z3 has no information about the return value, including that it must be a valid value of its declared type (e.g., u8 <= 255, vector has non-negative length), causing false verification failures.

Fix by emitting `assume $IsValid'<type>'(dest)` after calls to uninterpreted functions, following the existing pattern used for quantifier operations.