### PR TITLE
Refine pool annotations: conditional emission, multi-variable overloa…

### DIFF
--- a/crates/move-model/src/model.rs
+++ b/crates/move-model/src/model.rs
@@ -1597,6 +1597,7 @@ impl GlobalEnv {
     const LOG_GHOST_FUNCTION_NAME: &'static str = "ghost";
     const PROVER_VAL_FUNCTION_NAME: &'static str = "val";
     const PROVER_REF_FUNCTION_NAME: &'static str = "ref";
+    const PROVER_ADD_QUANTIFIER_POOL: &'static str = "add_quantifier_pool";
 
     // macro function names
 
@@ -2418,6 +2419,10 @@ impl GlobalEnv {
 
     pub fn prover_ref_qid(&self) -> QualifiedId<FunId> {
         self.get_fun_qid(Self::PROVER_MODULE_NAME, Self::PROVER_REF_FUNCTION_NAME)
+    }
+
+    pub fn prover_add_quantifier_pool_qid(&self) -> QualifiedId<FunId> {
+        self.get_fun_qid(Self::PROVER_MODULE_NAME, Self::PROVER_ADD_QUANTIFIER_POOL)
     }
 
     pub fn log_text_qid(&self) -> QualifiedId<FunId> {
@@ -3683,6 +3688,7 @@ impl GlobalEnv {
             self.invariant_end_qid(),
             self.prover_val_qid(),
             self.prover_ref_qid(),
+            self.prover_add_quantifier_pool_qid(),
         ]);
 
         // Prover vec iter module functions
@@ -3964,6 +3970,9 @@ impl GlobalEnv {
             self.declare_global_mut_qid(),
             self.havoc_global_qid(),
         ]);
+
+        // Prover module functions
+        qids.insert(self.prover_add_quantifier_pool_qid());
 
         // Prover vec iter module functions
         if self.has_prover_vector_module() {

--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -86,6 +86,7 @@ pub struct BoogieTranslator<'env> {
     targets: &'env FunctionTargetsHolder,
     types: &'env RefCell<BiBTreeMap<Type, String>>,
     asserts_mode: AssertsMode,
+    emitted_helpers: RefCell<BTreeSet<String>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -133,6 +134,7 @@ impl<'env> BoogieTranslator<'env> {
             types,
             spec_translator: SpecTranslator::new(writer, env, options),
             asserts_mode,
+            emitted_helpers: RefCell::new(BTreeSet::new()),
         }
     }
 
@@ -2232,6 +2234,7 @@ impl<'env> FunctionTranslator<'env> {
             fun_target.data.variant,
             fun_target.get_loc().display(env)
         );
+        self.emit_forall_exists_helpers();
         self.generate_function_sig();
 
         if self.fun_target.func_env.get_qualified_id() == self.parent.env.global_qid() {
@@ -2977,6 +2980,141 @@ impl<'env> FunctionTranslator<'env> {
         ids
     }
 
+    /// Emit helper function declarations + soundness axioms for any
+    /// Forall/Exists quantifiers in this function's bytecode. Called
+    /// before generate_function_sig so the declarations appear at the
+    /// top level in Boogie (outside the procedure).
+    fn emit_forall_exists_helpers(&self) {
+        let env = self.fun_target.global_env();
+        for bc in self.fun_target.get_bytecode() {
+            if let Bytecode::Call(_, _, Operation::Quantifier(qt, qid, inst, li), srcs, _) = bc {
+                if !matches!(qt, QuantifierType::Forall | QuantifierType::Exists) {
+                    continue;
+                }
+                let fun_env = env.get_function(*qid);
+                let inst = &self.inst_slice(inst);
+                let fun_name = boogie_function_name(&fun_env, inst, FunctionTranslationStyle::Pure);
+                let helper_name = format!(
+                    "${}Helper_{}",
+                    if matches!(qt, QuantifierType::Forall) {
+                        "Forall"
+                    } else {
+                        "Exists"
+                    },
+                    fun_name
+                );
+                if !self
+                    .parent
+                    .emitted_helpers
+                    .borrow_mut()
+                    .insert(helper_name.clone())
+                {
+                    continue; // already emitted
+                }
+
+                let loc_type = fun_env.get_parameter_types()[0]
+                    .skip_reference()
+                    .instantiate(inst);
+                let b_type = boogie_type(env, &loc_type);
+                let suffix = boogie_type_suffix(env, &loc_type);
+
+                // Build captured-variable parameter list
+                let params: Vec<String> = srcs
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != *li)
+                    .map(|(_, idx)| {
+                        let ty = self.get_local_type(*idx);
+                        format!("c{}: {}", idx, boogie_type(env, &ty))
+                    })
+                    .collect();
+                let args: Vec<String> = srcs
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != *li)
+                    .map(|(_, idx)| format!("c{}", idx))
+                    .collect();
+                let param_str = params.join(", ");
+                let arg_str = args.join(", ");
+
+                // Build pred call: fun_name(x, captured...)
+                let pred_args: String = srcs
+                    .iter()
+                    .enumerate()
+                    .map(|(i, idx)| {
+                        if i == *li {
+                            "x".to_string()
+                        } else {
+                            format!("c{}", idx)
+                        }
+                    })
+                    .join(", ");
+                let pred_call = format!("{}({})", fun_name, pred_args);
+
+                // Emit function declaration
+                emitln!(
+                    self.writer(),
+                    "function {}({}): bool;",
+                    helper_name,
+                    param_str
+                );
+
+                // Emit soundness axiom: helper(...) <==> (forall/exists x :: ...)
+                let helper_call = format!("{}({})", helper_name, arg_str);
+                if params.is_empty() {
+                    if matches!(qt, QuantifierType::Forall) {
+                        emitln!(
+                            self.writer(),
+                            "axiom ({} <==> (forall x: {} :: $IsValid'{}'(x) ==> {}));",
+                            helper_call,
+                            b_type,
+                            suffix,
+                            pred_call,
+                        );
+                    } else {
+                        emitln!(
+                            self.writer(),
+                            "axiom ({} <==> (exists x: {} :: $IsValid'{}'(x) && {}));",
+                            helper_call,
+                            b_type,
+                            suffix,
+                            pred_call,
+                        );
+                    }
+                } else {
+                    // With captured args: wrap in outer forall over captured params
+                    if matches!(qt, QuantifierType::Forall) {
+                        emitln!(
+                            self.writer(),
+                            "axiom (forall {} :: {{{}({})}} {}({}) <==> (forall x: {} :: $IsValid'{}'(x) ==> {}));",
+                            param_str,
+                            helper_name,
+                            arg_str,
+                            helper_name,
+                            arg_str,
+                            b_type,
+                            suffix,
+                            pred_call,
+                        );
+                    } else {
+                        emitln!(
+                            self.writer(),
+                            "axiom (forall {} :: {{{}({})}} {}({}) <==> (exists x: {} :: $IsValid'{}'(x) && {}));",
+                            param_str,
+                            helper_name,
+                            arg_str,
+                            helper_name,
+                            arg_str,
+                            b_type,
+                            suffix,
+                            pred_call,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     /// Check if the current spec's target function is referenced by any asserts_of declaration.
     fn has_asserts_of_ref(&self) -> bool {
         self.parent
@@ -3195,14 +3333,7 @@ impl<'env> FunctionTranslator<'env> {
                             let inst = &self.inst_slice(inst);
                             let pool_names = self.collect_pool_names();
                             self.generate_pure_quantifier_expr(
-                                qt,
-                                &qfun_env,
-                                inst,
-                                srcs,
-                                dests,
-                                *li,
-                                &fmt_temp,
-                                &pool_names,
+                                qt, &qfun_env, inst, srcs, dests, *li, &fmt_temp,
                             )
                         } else if let Operation::Pack(mid, sid, inst) = op {
                             let inst = &self.inst_slice(inst);
@@ -3468,16 +3599,8 @@ impl<'env> FunctionTranslator<'env> {
             _ => {
                 // All, Any, Map, Filter, etc. — use helper functions with
                 // top-level axioms that already carry {:pool}
-                let expr = self.generate_pure_quantifier_expr(
-                    qt,
-                    fun_env,
-                    inst,
-                    srcs,
-                    dests,
-                    li,
-                    fmt_temp,
-                    &BTreeSet::new(), // empty pool names → no inline pool
-                );
+                let expr = self
+                    .generate_pure_quantifier_expr(qt, fun_env, inst, srcs, dests, li, fmt_temp);
                 emitln!(self.writer(), "{} := {};", dest, expr);
             }
         }
@@ -3492,20 +3615,12 @@ impl<'env> FunctionTranslator<'env> {
         dests: &[TempIndex],
         li: usize,
         fmt_temp: &F,
-        pool_names: &BTreeSet<String>,
     ) -> String
     where
         F: Fn(usize) -> String,
     {
         let env = self.fun_target.global_env();
         let fun_name = &boogie_function_name(&fun_env, inst, FunctionTranslationStyle::Pure);
-        let kind = qt.display();
-        let pool_attr = Self::pool_annotation(pool_names, kind, fun_name);
-        let pool_str = if pool_attr.is_empty() {
-            String::new()
-        } else {
-            format!("{} ", pool_attr)
-        };
 
         let cr_args = |local_name: &str| -> String {
             if !qt.vector_based() {
@@ -3558,34 +3673,24 @@ impl<'env> FunctionTranslator<'env> {
 
         match qt {
             QuantifierType::Forall => {
-                let loc_type = fun_env.get_parameter_types()[0]
-                    .skip_reference()
-                    .instantiate(inst);
-                let b_type = boogie_type(env, &loc_type);
-                let suffix = boogie_type_suffix(env, &loc_type);
-                format!(
-                    "(forall {}x: {} :: $IsValid'{}'(x) ==> {}({}))",
-                    pool_str,
-                    b_type,
-                    suffix,
-                    fun_name,
-                    cr_args("x")
-                )
+                let helper_name = format!("$ForallHelper_{}", fun_name);
+                let captured: String = srcs
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != li)
+                    .map(|(_, idx)| fmt_temp(*idx))
+                    .join(", ");
+                format!("{}({})", helper_name, captured)
             }
             QuantifierType::Exists => {
-                let loc_type = fun_env.get_parameter_types()[0]
-                    .skip_reference()
-                    .instantiate(inst);
-                let b_type = boogie_type(env, &loc_type);
-                let suffix = boogie_type_suffix(env, &loc_type);
-                format!(
-                    "(exists {}x: {} :: $IsValid'{}'(x) && {}({}))",
-                    pool_str,
-                    b_type,
-                    suffix,
-                    fun_name,
-                    cr_args("x")
-                )
+                let helper_name = format!("$ExistsHelper_{}", fun_name);
+                let captured: String = srcs
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != li)
+                    .map(|(_, idx)| fmt_temp(*idx))
+                    .join(", ");
+                format!("{}({})", helper_name, captured)
             }
             QuantifierType::Any => {
                 let helper = self
@@ -5874,14 +5979,7 @@ impl<'env> FunctionTranslator<'env> {
                         if pool_attr.is_empty() {
                             // No pool: emit inline quantifier as before
                             let expr = self.generate_pure_quantifier_expr(
-                                qt,
-                                &qfun_env,
-                                inst,
-                                srcs,
-                                dests,
-                                *li,
-                                &fmt_temp,
-                                &pool_names,
+                                qt, &qfun_env, inst, srcs, dests, *li, &fmt_temp,
                             );
                             emitln!(self.writer(), "$t{} := {};", dests[0], expr);
                         } else {

--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -2977,28 +2977,6 @@ impl<'env> FunctionTranslator<'env> {
         ids
     }
 
-    fn create_quantifiers_temp_vars(&self) {
-        let mut has_find = false;
-        let mut has_quantifier_temp_vec = false;
-        for bc in self.fun_target.get_bytecode() {
-            if let Bytecode::Call(_, _, Operation::Quantifier(qt, _, _, _), _, _) = bc {
-                if qt.is_find_or_find_index() {
-                    has_find = true;
-                }
-                if qt.requires_sum() || qt.requires_filter_indices() {
-                    has_quantifier_temp_vec = true;
-                }
-            }
-        }
-        if has_find {
-            emitln!(self.parent.writer, "var $find_i: int;");
-            emitln!(self.parent.writer, "var $find_exists: bool;");
-        }
-        if has_quantifier_temp_vec {
-            emitln!(self.parent.writer, "var $quantifier_temp_vec: Vec int;");
-        }
-    }
-
     /// Check if the current spec's target function is referenced by any asserts_of declaration.
     fn has_asserts_of_ref(&self) -> bool {
         self.parent

--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -3503,115 +3503,6 @@ impl<'env> FunctionTranslator<'env> {
         }
     }
 
-    /// Emit a sound pool-based quantifier in a procedure body.
-    /// Instead of `$t := (forall {:pool} x :: P(x))` (unsound with empty pool),
-    /// emits assume-based axioms that constrain $t through pool terms:
-    ///   - forall: `assume (forall {:pool} x :: !P(x) ==> !$t)` (counterexample forces false)
-    ///   - exists: `assume (forall {:pool} x :: P(x) ==> $t)` (witness forces true)
-    fn emit_pooled_quantifier<F>(
-        &mut self,
-        qt: &QuantifierType,
-        fun_env: &FunctionEnv,
-        inst: &[Type],
-        srcs: &[TempIndex],
-        dests: &[TempIndex],
-        li: usize,
-        fmt_temp: &F,
-        pool_attr: &str,
-    ) where
-        F: Fn(usize) -> String,
-    {
-        let env = self.fun_target.global_env();
-        let fun_name = &boogie_function_name(fun_env, inst, FunctionTranslationStyle::Pure);
-        let pool_str = format!("{} ", pool_attr);
-        let dest = format!("$t{}", dests[0]);
-
-        let cr_args = |local_name: &str| -> String {
-            if !qt.vector_based() {
-                srcs.iter()
-                    .enumerate()
-                    .map(|(index, vidx)| {
-                        if index == li {
-                            local_name.to_string()
-                        } else {
-                            fmt_temp(*vidx)
-                        }
-                    })
-                    .join(", ")
-            } else {
-                srcs.iter()
-                    .skip(if qt.range_based() { 3 } else { 1 })
-                    .enumerate()
-                    .map(|(index, vidx)| {
-                        if index == li {
-                            format!("ReadVec({}, {})", fmt_temp(srcs[0]), local_name)
-                        } else {
-                            fmt_temp(*vidx)
-                        }
-                    })
-                    .join(", ")
-            }
-        };
-
-        match qt {
-            QuantifierType::Forall => {
-                let loc_type = fun_env.get_parameter_types()[0]
-                    .skip_reference()
-                    .instantiate(inst);
-                let b_type = boogie_type(env, &loc_type);
-                let suffix = boogie_type_suffix(env, &loc_type);
-                let pred = format!("{}({})", fun_name, cr_args("x"));
-                let guard = format!("$IsValid'{}'(x)", suffix);
-                // counterexample: !P(x) ==> !helper
-                emitln!(
-                    self.writer(),
-                    "assume (forall {}x: {} :: {} && !{} ==> !{});",
-                    pool_str,
-                    b_type,
-                    guard,
-                    pred,
-                    dest
-                );
-                // positive: helper ==> P(x)
-                emitln!(
-                    self.writer(),
-                    "assume (forall {}x: {} :: {} && {} ==> {});",
-                    pool_str,
-                    b_type,
-                    dest,
-                    guard,
-                    pred
-                );
-            }
-            QuantifierType::Exists => {
-                let loc_type = fun_env.get_parameter_types()[0]
-                    .skip_reference()
-                    .instantiate(inst);
-                let b_type = boogie_type(env, &loc_type);
-                let suffix = boogie_type_suffix(env, &loc_type);
-                let pred = format!("{}({})", fun_name, cr_args("x"));
-                let guard = format!("$IsValid'{}'(x)", suffix);
-                // witness: P(x) ==> helper
-                emitln!(
-                    self.writer(),
-                    "assume (forall {}x: {} :: {} && {} ==> {});",
-                    pool_str,
-                    b_type,
-                    guard,
-                    pred,
-                    dest
-                );
-            }
-            _ => {
-                // All, Any, Map, Filter, etc. — use helper functions with
-                // top-level axioms that already carry {:pool}
-                let expr = self
-                    .generate_pure_quantifier_expr(qt, fun_env, inst, srcs, dests, li, fmt_temp);
-                emitln!(self.writer(), "{} := {};", dest, expr);
-            }
-        }
-    }
-
     fn generate_pure_quantifier_expr<F>(
         &self,
         qt: &QuantifierType,
@@ -6015,24 +5906,10 @@ impl<'env> FunctionTranslator<'env> {
                         let qfun_env = self.parent.env.get_function(*qid);
                         let inst = &self.inst_slice(inst);
                         let fmt_temp = |idx: TempIndex| -> String { format!("$t{}", idx) };
-                        let pool_names = self.collect_pool_names();
-                        let fun_name =
-                            boogie_function_name(&qfun_env, inst, FunctionTranslationStyle::Pure);
-                        let pool_attr =
-                            Self::pool_annotation(&pool_names, &qt.display(), &fun_name);
-
-                        if pool_attr.is_empty() {
-                            // No pool: emit inline quantifier as before
-                            let expr = self.generate_pure_quantifier_expr(
-                                qt, &qfun_env, inst, srcs, dests, *li, &fmt_temp,
-                            );
-                            emitln!(self.writer(), "$t{} := {};", dests[0], expr);
-                        } else {
-                            // Pool active: emit sound wrapper using assume
-                            self.emit_pooled_quantifier(
-                                qt, &qfun_env, inst, srcs, dests, *li, &fmt_temp, &pool_attr,
-                            );
-                        }
+                        let expr = self.generate_pure_quantifier_expr(
+                            qt, &qfun_env, inst, srcs, dests, *li, &fmt_temp,
+                        );
+                        emitln!(self.writer(), "$t{} := {};", dests[0], expr);
                         // assume well-formedness of the uninterpreted result
                         let dest_ty = self.get_local_type(dests[0]).instantiate(inst);
                         emitln!(

--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -13,6 +13,7 @@ use std::{
 
 use bimap::btree::BiBTreeMap;
 use codespan::LineIndex;
+use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
 #[allow(unused_imports)]
 use log::{debug, info, log, warn, Level};
@@ -2934,6 +2935,68 @@ impl<'env> FunctionTranslator<'env> {
         self.parent.writer
     }
 
+    /// Collect pool names from add_quantifier_pool calls in the current function's bytecodes.
+    fn collect_pool_names(&self) -> BTreeSet<String> {
+        let pool_qid = self.parent.env.prover_add_quantifier_pool_qid();
+        super::lib::extract_pool_names_from_bytecode(pool_qid, self.fun_target.get_bytecode())
+    }
+
+    /// Strips the `$pure` suffix from a Boogie function name for use in pool identifiers.
+    fn strip_pure_suffix(name: &str) -> &str {
+        name.strip_suffix("$pure").unwrap_or(name)
+    }
+
+    /// Returns the `{:pool "kind-fun_name"}` annotation if any pool name is a substring of
+    /// `fun_name`, or an empty string if no match. The pool name is prefixed with the quantifier
+    /// kind for granular pool naming (e.g., `forall-$0x42_mod_f'u64'`).
+    fn pool_annotation(pool_names: &BTreeSet<String>, kind: &str, fun_name: &str) -> String {
+        let pool_id = Self::strip_pure_suffix(fun_name);
+        for pool_name in pool_names {
+            if pool_id.contains(pool_name.as_str()) {
+                return format!("{{:pool \"{}-{}\"}}", kind, pool_id);
+            }
+        }
+        String::new()
+    }
+
+    /// Collect all (quantifier_kind, pool_id) pairs from Quantifier operations.
+    /// The pool_id is the Boogie function name with the `$pure` suffix stripped.
+    fn collect_quantifier_pool_ids(&self) -> BTreeSet<(String, String)> {
+        let mut ids = BTreeSet::new();
+        for bc in self.fun_target.get_bytecode() {
+            if let Bytecode::Call(_, _, Operation::Quantifier(qt, qid, inst, _), _, _) = bc {
+                let fun_env = self.parent.env.get_function(*qid);
+                let inst = &self.inst_slice(inst);
+                let fun_name = boogie_function_name(&fun_env, inst, FunctionTranslationStyle::Pure);
+                let pool_id = Self::strip_pure_suffix(&fun_name).to_string();
+                ids.insert((qt.display().to_string(), pool_id));
+            }
+        }
+        ids
+    }
+
+    fn create_quantifiers_temp_vars(&self) {
+        let mut has_find = false;
+        let mut has_quantifier_temp_vec = false;
+        for bc in self.fun_target.get_bytecode() {
+            if let Bytecode::Call(_, _, Operation::Quantifier(qt, _, _, _), _, _) = bc {
+                if qt.is_find_or_find_index() {
+                    has_find = true;
+                }
+                if qt.requires_sum() || qt.requires_filter_indices() {
+                    has_quantifier_temp_vec = true;
+                }
+            }
+        }
+        if has_find {
+            emitln!(self.parent.writer, "var $find_i: int;");
+            emitln!(self.parent.writer, "var $find_exists: bool;");
+        }
+        if has_quantifier_temp_vec {
+            emitln!(self.parent.writer, "var $quantifier_temp_vec: Vec int;");
+        }
+    }
+
     /// Check if the current spec's target function is referenced by any asserts_of declaration.
     fn has_asserts_of_ref(&self) -> bool {
         self.parent
@@ -3150,8 +3213,16 @@ impl<'env> FunctionTranslator<'env> {
                         } else if let Quantifier(qt, qid, inst, li) = op {
                             let qfun_env = fun_target.global_env().get_function(*qid);
                             let inst = &self.inst_slice(inst);
+                            let pool_names = self.collect_pool_names();
                             self.generate_pure_quantifier_expr(
-                                qt, &qfun_env, inst, srcs, dests, *li, &fmt_temp,
+                                qt,
+                                &qfun_env,
+                                inst,
+                                srcs,
+                                dests,
+                                *li,
+                                &fmt_temp,
+                                &pool_names,
                             )
                         } else if let Operation::Pack(mid, sid, inst) = op {
                             let inst = &self.inst_slice(inst);
@@ -3315,6 +3386,195 @@ impl<'env> FunctionTranslator<'env> {
         }
     }
 
+    /// Emit a sound pool-based quantifier in a procedure body.
+    /// Instead of `$t := (forall {:pool} x :: P(x))` (unsound with empty pool),
+    /// emits assume-based axioms that constrain $t through pool terms:
+    ///   - forall: `assume (forall {:pool} x :: !P(x) ==> !$t)` (counterexample forces false)
+    ///   - exists: `assume (forall {:pool} x :: P(x) ==> $t)` (witness forces true)
+    fn emit_pooled_quantifier<F>(
+        &mut self,
+        qt: &QuantifierType,
+        fun_env: &FunctionEnv,
+        inst: &[Type],
+        srcs: &[TempIndex],
+        dests: &[TempIndex],
+        li: usize,
+        fmt_temp: &F,
+        pool_attr: &str,
+    ) where
+        F: Fn(usize) -> String,
+    {
+        let env = self.fun_target.global_env();
+        let fun_name = &boogie_function_name(fun_env, inst, FunctionTranslationStyle::Pure);
+        let pool_str = format!("{} ", pool_attr);
+        let dest = format!("$t{}", dests[0]);
+
+        let cr_args = |local_name: &str| -> String {
+            if !qt.vector_based() {
+                srcs.iter()
+                    .enumerate()
+                    .map(|(index, vidx)| {
+                        if index == li {
+                            local_name.to_string()
+                        } else {
+                            fmt_temp(*vidx)
+                        }
+                    })
+                    .join(", ")
+            } else {
+                srcs.iter()
+                    .skip(if qt.range_based() { 3 } else { 1 })
+                    .enumerate()
+                    .map(|(index, vidx)| {
+                        if index == li {
+                            format!("ReadVec({}, {})", fmt_temp(srcs[0]), local_name)
+                        } else {
+                            fmt_temp(*vidx)
+                        }
+                    })
+                    .join(", ")
+            }
+        };
+
+        match qt {
+            QuantifierType::Forall => {
+                let loc_type = fun_env.get_parameter_types()[0]
+                    .skip_reference()
+                    .instantiate(inst);
+                let b_type = boogie_type(env, &loc_type);
+                let suffix = boogie_type_suffix(env, &loc_type);
+                let pred = format!("{}({})", fun_name, cr_args("x"));
+                let guard = format!("$IsValid'{}'(x)", suffix);
+                // counterexample: !P(x) ==> !helper
+                emitln!(
+                    self.writer(),
+                    "assume (forall {}x: {} :: {} && !{} ==> !{});",
+                    pool_str,
+                    b_type,
+                    guard,
+                    pred,
+                    dest
+                );
+                // positive: helper ==> P(x)
+                emitln!(
+                    self.writer(),
+                    "assume (forall {}x: {} :: {} && {} ==> {});",
+                    pool_str,
+                    b_type,
+                    dest,
+                    guard,
+                    pred
+                );
+            }
+            QuantifierType::Exists => {
+                let loc_type = fun_env.get_parameter_types()[0]
+                    .skip_reference()
+                    .instantiate(inst);
+                let b_type = boogie_type(env, &loc_type);
+                let suffix = boogie_type_suffix(env, &loc_type);
+                let pred = format!("{}({})", fun_name, cr_args("x"));
+                let guard = format!("$IsValid'{}'(x)", suffix);
+                // witness: P(x) ==> helper
+                emitln!(
+                    self.writer(),
+                    "assume (forall {}x: {} :: {} && {} ==> {});",
+                    pool_str,
+                    b_type,
+                    guard,
+                    pred,
+                    dest
+                );
+            }
+            QuantifierType::All => {
+                let v = fmt_temp(srcs[0]);
+                let pred = format!("{}({})", fun_name, cr_args("i"));
+                // counterexample: element doesn't satisfy ==> !helper
+                emitln!(
+                    self.writer(),
+                    "assume (forall {}i: int :: 0 <= i && i < LenVec({}) && !{} ==> !{});",
+                    pool_str,
+                    v,
+                    pred,
+                    dest
+                );
+                // positive: helper ==> all elements satisfy
+                emitln!(
+                    self.writer(),
+                    "assume (forall {}i: int :: {} && 0 <= i && i < LenVec({}) ==> {});",
+                    pool_str,
+                    dest,
+                    v,
+                    pred
+                );
+            }
+            QuantifierType::AllRange => {
+                let start = fmt_temp(srcs[1]);
+                let end = fmt_temp(srcs[2]);
+                let pred = format!("{}({})", fun_name, cr_args("i"));
+                emitln!(
+                    self.writer(),
+                    "assume (forall {}i: int :: {} <= i && i < {} && !{} ==> !{});",
+                    pool_str,
+                    start,
+                    end,
+                    pred,
+                    dest
+                );
+                emitln!(
+                    self.writer(),
+                    "assume (forall {}i: int :: {} && {} <= i && i < {} ==> {});",
+                    pool_str,
+                    dest,
+                    start,
+                    end,
+                    pred
+                );
+            }
+            QuantifierType::Any => {
+                let v = fmt_temp(srcs[0]);
+                let pred = format!("{}({})", fun_name, cr_args("i"));
+                // witness: element satisfies ==> helper
+                emitln!(
+                    self.writer(),
+                    "assume (forall {}i: int :: 0 <= i && i < LenVec({}) && {} ==> {});",
+                    pool_str,
+                    v,
+                    pred,
+                    dest
+                );
+            }
+            QuantifierType::AnyRange => {
+                let start = fmt_temp(srcs[1]);
+                let end = fmt_temp(srcs[2]);
+                let pred = format!("{}({})", fun_name, cr_args("i"));
+                emitln!(
+                    self.writer(),
+                    "assume (forall {}i: int :: {} <= i && i < {} && {} ==> {});",
+                    pool_str,
+                    start,
+                    end,
+                    pred,
+                    dest
+                );
+            }
+            _ => {
+                // Map, Filter, etc. — don't use pool wrappers, their axioms
+                // are at the top level and already have {:pool}
+                let expr = self.generate_pure_quantifier_expr(
+                    qt,
+                    fun_env,
+                    inst,
+                    srcs,
+                    dests,
+                    li,
+                    fmt_temp,
+                    &BTreeSet::new(), // empty pool names → no inline pool
+                );
+                emitln!(self.writer(), "{} := {};", dest, expr);
+            }
+        }
+    }
+
     fn generate_pure_quantifier_expr<F>(
         &self,
         qt: &QuantifierType,
@@ -3324,12 +3584,20 @@ impl<'env> FunctionTranslator<'env> {
         dests: &[TempIndex],
         li: usize,
         fmt_temp: &F,
+        pool_names: &BTreeSet<String>,
     ) -> String
     where
         F: Fn(usize) -> String,
     {
         let env = self.fun_target.global_env();
         let fun_name = &boogie_function_name(&fun_env, inst, FunctionTranslationStyle::Pure);
+        let kind = qt.display();
+        let pool_attr = Self::pool_annotation(pool_names, kind, fun_name);
+        let pool_str = if pool_attr.is_empty() {
+            String::new()
+        } else {
+            format!("{} ", pool_attr)
+        };
 
         let cr_args = |local_name: &str| -> String {
             if !qt.vector_based() {
@@ -3388,7 +3656,8 @@ impl<'env> FunctionTranslator<'env> {
                 let b_type = boogie_type(env, &loc_type);
                 let suffix = boogie_type_suffix(env, &loc_type);
                 format!(
-                    "(forall x: {} :: $IsValid'{}'(x) ==> {}({}))",
+                    "(forall {}x: {} :: $IsValid'{}'(x) ==> {}({}))",
+                    pool_str,
                     b_type,
                     suffix,
                     fun_name,
@@ -3402,7 +3671,8 @@ impl<'env> FunctionTranslator<'env> {
                 let b_type = boogie_type(env, &loc_type);
                 let suffix = boogie_type_suffix(env, &loc_type);
                 format!(
-                    "(exists x: {} :: $IsValid'{}'(x) && {}({}))",
+                    "(exists {}x: {} :: $IsValid'{}'(x) && {}({}))",
+                    pool_str,
                     b_type,
                     suffix,
                     fun_name,
@@ -3411,7 +3681,8 @@ impl<'env> FunctionTranslator<'env> {
             }
             QuantifierType::Any => {
                 format!(
-                    "(exists i:int :: 0 <= i && i < LenVec({}) && {}({}))",
+                    "(exists {}i:int :: 0 <= i && i < LenVec({}) && {}({}))",
+                    pool_str,
                     fmt_temp(srcs[0]),
                     fun_name,
                     cr_args("i")
@@ -3419,7 +3690,8 @@ impl<'env> FunctionTranslator<'env> {
             }
             QuantifierType::AnyRange => {
                 format!(
-                    "(exists i:int :: {} <= i && i < {} && {}({}))",
+                    "(exists {}i:int :: {} <= i && i < {} && {}({}))",
+                    pool_str,
                     fmt_temp(srcs[1]),
                     fmt_temp(srcs[2]),
                     fun_name,
@@ -3428,7 +3700,8 @@ impl<'env> FunctionTranslator<'env> {
             }
             QuantifierType::All => {
                 format!(
-                    "(forall i:int :: 0 <= i && i < LenVec({}) ==> {}({}))",
+                    "(forall {}i:int :: 0 <= i && i < LenVec({}) ==> {}({}))",
+                    pool_str,
                     fmt_temp(srcs[0]),
                     fun_name,
                     cr_args("i")
@@ -3436,7 +3709,8 @@ impl<'env> FunctionTranslator<'env> {
             }
             QuantifierType::AllRange => {
                 format!(
-                    "(forall i:int :: {} <= i && i < {} ==> {}({}))",
+                    "(forall {}i:int :: {} <= i && i < {} ==> {}({}))",
+                    pool_str,
                     fmt_temp(srcs[1]),
                     fmt_temp(srcs[2]),
                     fun_name,
@@ -4292,6 +4566,59 @@ impl<'env> FunctionTranslator<'env> {
                                 secondary,
                                 args_str,
                             );
+                            processed = true;
+                        }
+
+                        if callee_env.get_qualified_id()
+                            == self.parent.env.prover_add_quantifier_pool_qid()
+                        {
+                            // Extract pool name from the ByteArray constant loaded into srcs[0]
+                            let user_pool_name = self
+                                .fun_target
+                                .get_bytecode()
+                                .iter()
+                                .find_map(|bc| {
+                                    if let Bytecode::Load(_, dest, Constant::ByteArray(val)) = bc {
+                                        if *dest == srcs[0] {
+                                            return Some(
+                                                String::from_utf8(val.clone()).unwrap_or_else(
+                                                    |_| format!("pool_{}", srcs[0]),
+                                                ),
+                                            );
+                                        }
+                                    }
+                                    None
+                                })
+                                .unwrap_or_else(|| format!("pool_{}", srcs[0]));
+                            // Find all quantifier functions whose Boogie names contain
+                            // the user's pool name, and emit {:add_to_pool} for each
+                            let quantifier_pool_ids = self.collect_quantifier_pool_ids();
+                            let matching_ids: Vec<_> = quantifier_pool_ids
+                                .iter()
+                                .filter(|(_, name)| name.contains(&user_pool_name))
+                                .collect();
+                            for (kind, boogie_name) in &matching_ids {
+                                for src_idx in &srcs[1..] {
+                                    let term_str = str_local(*src_idx);
+                                    emitln!(
+                                        self.writer(),
+                                        "assume {{:add_to_pool \"{}-{}\", {}}} true;",
+                                        kind,
+                                        boogie_name,
+                                        term_str,
+                                    );
+                                }
+                            }
+                            if matching_ids.is_empty() {
+                                env.diag(
+                                    Severity::Warning,
+                                    &self.fun_target.get_loc(),
+                                    &format!(
+                                        "add_quantifier_pool: no quantifier found matching pool name \"{}\"",
+                                        user_pool_name
+                                    ),
+                                );
+                            }
                             processed = true;
                         }
 
@@ -5620,10 +5947,31 @@ impl<'env> FunctionTranslator<'env> {
                         let qfun_env = self.parent.env.get_function(*qid);
                         let inst = &self.inst_slice(inst);
                         let fmt_temp = |idx: TempIndex| -> String { format!("$t{}", idx) };
-                        let expr = self.generate_pure_quantifier_expr(
-                            qt, &qfun_env, inst, srcs, dests, *li, &fmt_temp,
-                        );
-                        emitln!(self.writer(), "$t{} := {};", dests[0], expr);
+                        let pool_names = self.collect_pool_names();
+                        let fun_name =
+                            boogie_function_name(&qfun_env, inst, FunctionTranslationStyle::Pure);
+                        let pool_attr =
+                            Self::pool_annotation(&pool_names, &qt.display(), &fun_name);
+
+                        if pool_attr.is_empty() {
+                            // No pool: emit inline quantifier as before
+                            let expr = self.generate_pure_quantifier_expr(
+                                qt,
+                                &qfun_env,
+                                inst,
+                                srcs,
+                                dests,
+                                *li,
+                                &fmt_temp,
+                                &pool_names,
+                            );
+                            emitln!(self.writer(), "$t{} := {};", dests[0], expr);
+                        } else {
+                            // Pool active: emit sound wrapper using assume
+                            self.emit_pooled_quantifier(
+                                qt, &qfun_env, inst, srcs, dests, *li, &fmt_temp, &pool_attr,
+                            );
+                        }
                         // assume well-formedness of the uninterpreted result
                         let dest_ty = self.get_local_type(dests[0]).instantiate(inst);
                         emitln!(

--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -161,6 +161,8 @@ impl<'env> BoogieTranslator<'env> {
             QuantifierHelperType::Filter => format!("$FilterQuantifierHelper_{}", function_name),
             QuantifierHelperType::Count => format!("$CountQuantifierHelper_{}", function_name),
             QuantifierHelperType::SumMap => format!("$SumMapQuantifierHelper_{}", function_name),
+            QuantifierHelperType::All => format!("$AllQuantifierHelper_{}", function_name),
+            QuantifierHelperType::Any => format!("$AnyQuantifierHelper_{}", function_name),
         }
     }
 
@@ -3485,81 +3487,9 @@ impl<'env> FunctionTranslator<'env> {
                     dest
                 );
             }
-            QuantifierType::All => {
-                let v = fmt_temp(srcs[0]);
-                let pred = format!("{}({})", fun_name, cr_args("i"));
-                // counterexample: element doesn't satisfy ==> !helper
-                emitln!(
-                    self.writer(),
-                    "assume (forall {}i: int :: 0 <= i && i < LenVec({}) && !{} ==> !{});",
-                    pool_str,
-                    v,
-                    pred,
-                    dest
-                );
-                // positive: helper ==> all elements satisfy
-                emitln!(
-                    self.writer(),
-                    "assume (forall {}i: int :: {} && 0 <= i && i < LenVec({}) ==> {});",
-                    pool_str,
-                    dest,
-                    v,
-                    pred
-                );
-            }
-            QuantifierType::AllRange => {
-                let start = fmt_temp(srcs[1]);
-                let end = fmt_temp(srcs[2]);
-                let pred = format!("{}({})", fun_name, cr_args("i"));
-                emitln!(
-                    self.writer(),
-                    "assume (forall {}i: int :: {} <= i && i < {} && !{} ==> !{});",
-                    pool_str,
-                    start,
-                    end,
-                    pred,
-                    dest
-                );
-                emitln!(
-                    self.writer(),
-                    "assume (forall {}i: int :: {} && {} <= i && i < {} ==> {});",
-                    pool_str,
-                    dest,
-                    start,
-                    end,
-                    pred
-                );
-            }
-            QuantifierType::Any => {
-                let v = fmt_temp(srcs[0]);
-                let pred = format!("{}({})", fun_name, cr_args("i"));
-                // witness: element satisfies ==> helper
-                emitln!(
-                    self.writer(),
-                    "assume (forall {}i: int :: 0 <= i && i < LenVec({}) && {} ==> {});",
-                    pool_str,
-                    v,
-                    pred,
-                    dest
-                );
-            }
-            QuantifierType::AnyRange => {
-                let start = fmt_temp(srcs[1]);
-                let end = fmt_temp(srcs[2]);
-                let pred = format!("{}({})", fun_name, cr_args("i"));
-                emitln!(
-                    self.writer(),
-                    "assume (forall {}i: int :: {} <= i && i < {} && {} ==> {});",
-                    pool_str,
-                    start,
-                    end,
-                    pred,
-                    dest
-                );
-            }
             _ => {
-                // Map, Filter, etc. — don't use pool wrappers, their axioms
-                // are at the top level and already have {:pool}
+                // All, Any, Map, Filter, etc. — use helper functions with
+                // top-level axioms that already carry {:pool}
                 let expr = self.generate_pure_quantifier_expr(
                     qt,
                     fun_env,
@@ -3680,41 +3610,51 @@ impl<'env> FunctionTranslator<'env> {
                 )
             }
             QuantifierType::Any => {
+                let helper = self
+                    .parent
+                    .get_quantifier_helper_name(QuantifierHelperType::Any, fun_name);
                 format!(
-                    "(exists {}i:int :: 0 <= i && i < LenVec({}) && {}({}))",
-                    pool_str,
+                    "{0}({1}, 0, LenVec({1}){2})",
+                    helper,
                     fmt_temp(srcs[0]),
-                    fun_name,
-                    cr_args("i")
+                    extra_args,
                 )
             }
             QuantifierType::AnyRange => {
+                let helper = self
+                    .parent
+                    .get_quantifier_helper_name(QuantifierHelperType::Any, fun_name);
                 format!(
-                    "(exists {}i:int :: {} <= i && i < {} && {}({}))",
-                    pool_str,
+                    "{}({}, {}, {}{})",
+                    helper,
+                    fmt_temp(srcs[0]),
                     fmt_temp(srcs[1]),
                     fmt_temp(srcs[2]),
-                    fun_name,
-                    cr_args("i")
+                    extra_args,
                 )
             }
             QuantifierType::All => {
+                let helper = self
+                    .parent
+                    .get_quantifier_helper_name(QuantifierHelperType::All, fun_name);
                 format!(
-                    "(forall {}i:int :: 0 <= i && i < LenVec({}) ==> {}({}))",
-                    pool_str,
+                    "{0}({1}, 0, LenVec({1}){2})",
+                    helper,
                     fmt_temp(srcs[0]),
-                    fun_name,
-                    cr_args("i")
+                    extra_args,
                 )
             }
             QuantifierType::AllRange => {
+                let helper = self
+                    .parent
+                    .get_quantifier_helper_name(QuantifierHelperType::All, fun_name);
                 format!(
-                    "(forall {}i:int :: {} <= i && i < {} ==> {}({}))",
-                    pool_str,
+                    "{}({}, {}, {}{})",
+                    helper,
+                    fmt_temp(srcs[0]),
                     fmt_temp(srcs[1]),
                     fmt_temp(srcs[2]),
-                    fun_name,
-                    cr_args("i")
+                    extra_args,
                 )
             }
             QuantifierType::Map => {

--- a/crates/move-prover-boogie-backend/src/boogie_backend/lib.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/lib.rs
@@ -60,6 +60,8 @@ struct TypeInfo {
     /// True for U8..U256 (fixed-width unsigned). False for Num (arbitrary precision).
     is_unsigned: bool,
     bit_width: String,
+    /// True when any user-provided pool name is a substring of this type's suffix.
+    has_pool: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -260,12 +262,14 @@ pub fn add_prelude(
     context.insert("options", options);
 
     let mono_info = mono_analysis::get_info(env);
+    let pool_names = collect_all_pool_names(env, targets);
     // Add vector instances implicitly used by the prelude.
     let implicit_vec_inst = vec![TypeInfo::new(
         env,
         options,
         &Type::Primitive(PrimitiveType::U8),
         false,
+        &pool_names,
     )];
     // Used for generating functions for bv types in prelude
     let mut sh_instances = vec![8, 16, 32, 64, 128, 256];
@@ -280,7 +284,7 @@ pub fn add_prelude(
     let mut vec_instances = mono_info
         .vec_inst
         .iter()
-        .map(|ty| TypeInfo::new(env, options, ty, false))
+        .map(|ty| TypeInfo::new(env, options, ty, false, &pool_names))
         .chain(implicit_vec_inst)
         .collect::<BTreeSet<_>>()
         .into_iter()
@@ -339,7 +343,7 @@ pub fn add_prelude(
         let mut bv_vec_instances = mono_info
             .vec_inst
             .iter()
-            .map(|ty| TypeInfo::new(env, options, ty, true))
+            .map(|ty| TypeInfo::new(env, options, ty, true, &pool_names))
             .filter(|ty_info| !vec_instances.contains(ty_info))
             .collect::<BTreeSet<_>>()
             .into_iter()
@@ -370,7 +374,7 @@ pub fn add_prelude(
                     .get(&option_env.get_qualified_id())
                     .unwrap_or(&BTreeSet::new())
                     .iter()
-                    .map(|tys| TypeInfo::new(env, options, &tys[0], false))
+                    .map(|tys| TypeInfo::new(env, options, &tys[0], false, &BTreeSet::new()))
                     .collect_vec()
             } else {
                 vec![]
@@ -393,7 +397,7 @@ pub fn add_prelude(
                 .get(&vec_set_struct_env.get_qualified_id())
                 .unwrap_or(&BTreeSet::new())
                 .iter()
-                .map(|tys| TypeInfo::new(env, options, &tys[0], false))
+                .map(|tys| TypeInfo::new(env, options, &tys[0], false, &BTreeSet::new()))
                 .collect_vec()
         } else {
             vec![]
@@ -418,8 +422,8 @@ pub fn add_prelude(
                 .iter()
                 .map(|tys| {
                     (
-                        TypeInfo::new(env, options, &tys[0], false),
-                        TypeInfo::new(env, options, &tys[1], false),
+                        TypeInfo::new(env, options, &tys[0], false, &BTreeSet::new()),
+                        TypeInfo::new(env, options, &tys[1], false, &pool_names),
                     )
                 })
                 .collect_vec()
@@ -441,7 +445,7 @@ pub fn add_prelude(
                     .get(&table_vec_env.get_qualified_id())
                     .unwrap_or(&BTreeSet::new())
                     .iter()
-                    .map(|tys| TypeInfo::new(env, options, &tys[0], false))
+                    .map(|tys| TypeInfo::new(env, options, &tys[0], false, &BTreeSet::new()))
                     .collect_vec()
             } else {
                 vec![]
@@ -484,7 +488,7 @@ pub fn add_prelude(
             .flat_map(|(_, insts)| {
                 insts.iter().map(|inst| {
                     inst.iter()
-                        .map(|i| TypeInfo::new(env, options, i, false))
+                        .map(|i| TypeInfo::new(env, options, i, false, &pool_names))
                         .collect::<Vec<_>>()
                 })
             })
@@ -548,7 +552,6 @@ pub fn add_prelude(
         }
     }
 
-    let pool_names = collect_all_pool_names(env, targets);
     context.insert(
         "quantifier_helpers_instances",
         &mono_info
@@ -712,16 +715,25 @@ impl QuantifierHelperInfo {
 }
 
 impl TypeInfo {
-    fn new(env: &GlobalEnv, options: &BoogieOptions, ty: &Type, bv_flag: bool) -> Self {
+    fn new(
+        env: &GlobalEnv,
+        options: &BoogieOptions,
+        ty: &Type,
+        bv_flag: bool,
+        pool_names: &BTreeSet<String>,
+    ) -> Self {
         let name_fun = if bv_flag { boogie_bv_type } else { boogie_type };
+        let suffix = boogie_type_suffix_bv(env, ty, bv_flag);
+        let has_pool = pool_names.iter().any(|pn| suffix.contains(pn.as_str()));
         Self {
             name: name_fun(env, ty),
-            suffix: boogie_type_suffix_bv(env, ty, bv_flag),
+            suffix,
             has_native_equality: has_native_equality(env, options, ty),
             is_bv: bv_flag && ty.is_number(),
             bit_width: ty.get_bit_width().unwrap_or(8).to_string(),
             is_number: ty.is_number(),
             is_unsigned: ty.get_bit_width().is_some(),
+            has_pool,
         }
     }
 }
@@ -741,8 +753,8 @@ impl TableImpl {
             .flat_map(|type_insts| {
                 type_insts.iter().map(|tys| {
                     (
-                        TypeInfo::new(env, options, &tys[0], false),
-                        TypeInfo::new(env, options, &tys[1], bv_flag),
+                        TypeInfo::new(env, options, &tys[0], false, &BTreeSet::new()),
+                        TypeInfo::new(env, options, &tys[1], bv_flag, &BTreeSet::new()),
                     )
                 })
             })
@@ -801,8 +813,8 @@ impl TableImpl {
             .flat_map(|type_insts| {
                 type_insts.iter().map(|tys| {
                     (
-                        TypeInfo::new(env, options, &tys[0], false),
-                        TypeInfo::new(env, options, &tys[1], bv_flag),
+                        TypeInfo::new(env, options, &tys[0], false, &BTreeSet::new()),
+                        TypeInfo::new(env, options, &tys[1], bv_flag, &BTreeSet::new()),
                     )
                 })
             })
@@ -865,8 +877,8 @@ impl DynamicFieldInfo {
             .unique()
             .map(|(name, value)| {
                 (
-                    TypeInfo::new(env, options, name, false),
-                    TypeInfo::new(env, options, value, bv_flag),
+                    TypeInfo::new(env, options, name, false, &BTreeSet::new()),
+                    TypeInfo::new(env, options, value, bv_flag, &BTreeSet::new()),
                 )
             })
             .collect();
@@ -874,7 +886,7 @@ impl DynamicFieldInfo {
             .iter()
             .map(|name_value_info| name_value_info.name())
             .unique()
-            .map(|name| TypeInfo::new(env, options, name, false))
+            .map(|name| TypeInfo::new(env, options, name, false, &BTreeSet::new()))
             .collect_vec();
 
         DynamicFieldInfo {
@@ -919,8 +931,8 @@ impl DynamicFieldInfo {
             .unique()
             .map(|(name, value)| {
                 (
-                    TypeInfo::new(env, options, name, false),
-                    TypeInfo::new(env, options, value, bv_flag),
+                    TypeInfo::new(env, options, name, false, &BTreeSet::new()),
+                    TypeInfo::new(env, options, value, bv_flag, &BTreeSet::new()),
                 )
             })
             .collect();
@@ -928,7 +940,7 @@ impl DynamicFieldInfo {
             .iter()
             .map(|name_value_info| name_value_info.name())
             .unique()
-            .map(|name| TypeInfo::new(env, options, name, false))
+            .map(|name| TypeInfo::new(env, options, name, false, &BTreeSet::new()))
             .collect_vec();
 
         DynamicFieldInfo {

--- a/crates/move-prover-boogie-backend/src/boogie_backend/lib.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/lib.rs
@@ -22,7 +22,7 @@ use move_stackless_bytecode::{
     dynamic_field_analysis::{self, NameValueInfo},
     function_target_pipeline::{FunctionTargetsHolder, FunctionVariant},
     mono_analysis::{self, MonoInfo, PureQuantifierHelperInfo},
-    stackless_bytecode::QuantifierHelperType,
+    stackless_bytecode::{Bytecode, Constant, Operation, QuantifierHelperType},
     verification_analysis,
 };
 
@@ -66,6 +66,8 @@ struct TypeInfo {
 struct QuantifierHelperInfo {
     qht: String,
     name: String,
+    pool_id: String,
+    has_pool: bool,
     quantifier_params: String,
     quantifier_args: String,
     result_type: String,
@@ -184,6 +186,43 @@ fn should_include_vec_sum(env: &GlobalEnv, targets: &FunctionTargetsHolder) -> b
     });
 
     sum_func_inlined || sum_range_func_inlined
+}
+
+/// Extracts pool name strings from `add_quantifier_pool` calls in a bytecode slice.
+pub(crate) fn extract_pool_names_from_bytecode(
+    pool_qid: QualifiedId<FunId>,
+    code: &[Bytecode],
+) -> BTreeSet<String> {
+    let mut pool_names = BTreeSet::new();
+    for bc in code {
+        if let Bytecode::Call(_, _, Operation::Function(mid, fid, _), srcs, _) = bc {
+            if mid.qualified(*fid) == pool_qid {
+                if let Some(name) = code.iter().find_map(|bc2| {
+                    if let Bytecode::Load(_, dest, Constant::ByteArray(val)) = bc2 {
+                        if *dest == srcs[0] {
+                            return String::from_utf8(val.clone()).ok();
+                        }
+                    }
+                    None
+                }) {
+                    pool_names.insert(name);
+                }
+            }
+        }
+    }
+    pool_names
+}
+
+/// Collects all pool name strings from `add_quantifier_pool` calls across all functions.
+fn collect_all_pool_names(env: &GlobalEnv, targets: &FunctionTargetsHolder) -> BTreeSet<String> {
+    let pool_qid = env.prover_add_quantifier_pool_qid();
+    let mut pool_names = BTreeSet::new();
+    for (fun_id, variant) in targets.get_funs_and_variants() {
+        if let Some(data) = targets.get_data(&fun_id, &variant) {
+            pool_names.extend(extract_pool_names_from_bytecode(pool_qid, &data.code));
+        }
+    }
+    pool_names
 }
 
 /// Adds the prelude to the generated output.
@@ -509,12 +548,13 @@ pub fn add_prelude(
         }
     }
 
+    let pool_names = collect_all_pool_names(env, targets);
     context.insert(
         "quantifier_helpers_instances",
         &mono_info
             .quantifier_helpers
             .iter()
-            .map(|info| QuantifierHelperInfo::new(env, info))
+            .map(|info| QuantifierHelperInfo::new(env, info, &pool_names))
             .collect_vec(),
     );
 
@@ -560,7 +600,11 @@ fn triple_opt_to_name(env: &GlobalEnv, triple_opt: Option<QualifiedId<FunId>>) -
 }
 
 impl QuantifierHelperInfo {
-    fn new(env: &GlobalEnv, info: &PureQuantifierHelperInfo) -> Self {
+    fn new(
+        env: &GlobalEnv,
+        info: &PureQuantifierHelperInfo,
+        pool_names: &BTreeSet<String>,
+    ) -> Self {
         let func_env = env.get_function(info.function);
         let params_types = Type::instantiate_vec(func_env.get_parameter_types(), &info.inst);
 
@@ -600,6 +644,10 @@ impl QuantifierHelperInfo {
                 .join(", ");
             quantifier_args = format!("{}, {}", quantifier_args, captured_list);
         }
+
+        let name = boogie_function_name(&func_env, &info.inst, FunctionTranslationStyle::Pure);
+        let pool_id = name.strip_suffix("$pure").unwrap_or(&name).to_string();
+        let has_pool = pool_names.iter().any(|pn| pool_id.contains(pn.as_str()));
 
         // RT and $IsValid suffix are only used by vector-valued helpers
         let (result_type, result_is_valid_suffix) = if matches!(
@@ -643,7 +691,9 @@ impl QuantifierHelperInfo {
 
         Self {
             qht: info.qht.str().to_string(),
-            name: boogie_function_name(&func_env, &info.inst, FunctionTranslationStyle::Pure),
+            name,
+            pool_id,
+            has_pool,
             quantifier_params,
             quantifier_args,
             result_type,

--- a/crates/move-prover-boogie-backend/src/boogie_backend/prelude/native.bpl
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/prelude/native.bpl
@@ -24,7 +24,7 @@ function $IsValid'$1_option_Option{{S}}'(opt: $1_option_Option{{S}}): bool {
 {% macro vector_module(instance) %}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}
-{%- set VPOOL = '{:pool "vec' ~ S ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "vec' ~ S ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 {%- if options.native_equality -%}
 {# Whole vector has native equality #}
 function {:inline} $IsEqual'vec{{S}}'(v1: Vec ({{T}}), v2: Vec ({{T}})): bool {
@@ -534,7 +534,7 @@ function {:inline} $0_vector_iter_sum_range{{S}}(v: Vec ({{T}}), start: int, end
 {% macro vec_set_module(instance) %}
 {%- set T = instance.name -%}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
-{%- set VPOOL = '{:pool "vec_set' ~ S ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "vec_set' ~ S ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 
 procedure {:inline 1} $2_vec_set_get_idx_opt{{S}}(
     s: $2_vec_set_VecSet{{S}},
@@ -608,7 +608,7 @@ function {:inline} $2_vec_set_remove_pure{{S}}(s: $2_vec_set_VecSet{{S}}, k: {{T
 {%- set T = instance.name -%}
 {%- set T_S = instance.suffix -%}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
-{%- set VPOOL = '{:pool "table_vec' ~ S ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "table_vec' ~ S ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 
 function $IsValid'$2_table_vec_TableVec{{S}}'(s: $2_table_vec_TableVec{{S}}): bool {
     $IsValid'$2_table_Table'u64_{{T_S}}''(s->$contents) &&
@@ -627,7 +627,7 @@ function $IsValid'$2_table_vec_TableVec{{S}}'(s: $2_table_vec_TableVec{{S}}): bo
 {%- set K_S = "'" ~ key_instance.suffix ~ "'" -%}
 {%- set V_S = "'" ~ value_instance.suffix ~ "'" -%}
 {%- set S = "'" ~ key_instance.suffix ~ "_" ~ value_instance.suffix ~ "'" -%}
-{%- set VPOOL = '{:pool "vec_map' ~ S ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "vec_map' ~ S ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 
 function {:inline} $ContainsVecMap{{S}}(v: Vec ($2_vec_map_Entry{{S}}), k: {{K}}): bool {
     (exists i: int :: $IsValid'u64'(i) && InRangeVec(v, i) && $IsEqual{{K_S}}(ReadVec(v, i)->$key, k))
@@ -787,7 +787,7 @@ function {:inline} $2_vec_map_remove_pure{{S}}(vm: $2_vec_map_VecMap{{S}}, key: 
 {% macro table_key_encoding(instance) %}
 {%- set K = instance.name -%}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
-{%- set VPOOL = '{:pool "table_key' ~ S ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "table_key' ~ S ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 
 function $EncodeKey{{S}}(k: {{K}}): int;
 axiom (
@@ -801,7 +801,7 @@ axiom (
 {%- set Self = "Table int (" ~ V ~ ")" -%}
 {%- set S = "'" ~ "Table" ~ "'" ~ "int" ~ "_" ~ instance.suffix ~ "'" ~ "'" -%}
 {%- set SV = "'" ~ instance.suffix ~ "'" -%}
-{%- set VPOOL = '{:pool "table' ~ SV ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "table' ~ SV ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 
 {%- if options.native_equality -%}
 function $IsEqual'{{S}}'(t1: {{Self}}, t2: {{Self}}): bool {
@@ -832,7 +832,7 @@ function $IsValid'{{S}}'(t: {{Self}}): bool {
 {%- set S = "'" ~ instance.0.suffix ~ "_" ~ instance.1.suffix ~ "'" -%}
 {%- set SV = "'" ~ instance.1.suffix ~ "'" -%}
 {%- set ENC = "$EncodeKey'" ~ instance.0.suffix ~ "'" -%}
-{%- set VPOOL = '{:pool "table' ~ S ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "table' ~ S ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 
 datatype {{Type}}{{S}} {
     {{Type}}{{S}}($id: $2_object_UID, $contents: {{Self}})
@@ -1004,7 +1004,7 @@ procedure {:inline 2} {{impl.fun_drop}}{{S}}(t: {{Type}}{{S}}) {}
 {%- set SV = "'" ~ instance.1.suffix ~ "'" -%}
 {%- set DF_S = "'" ~ instance.0.suffix ~ "_" ~ instance.1.suffix ~ "_" ~ impl.struct_name ~ "'" -%}
 {%- set ENC = "$EncodeKey'" ~ instance.0.suffix ~ "'" -%}
-{%- set VPOOL = '{:pool "df' ~ S ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "df' ~ S ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 
 {%- if impl.fun_add != "" %}
 procedure {:inline 2} {{impl.fun_add}}{{DF_S}}(m: $Mutation ({{Type}}), k: {{K}}, v: {{V}}) returns (m': $Mutation({{Type}})) {
@@ -1711,7 +1711,7 @@ function {:inline} {{impl.fun_exists}}{{DF_S}}(t: {{Type}}, k: {{T}}): bool {
 {% macro bcs_module(instance) %}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}
-{%- set VPOOL = '{:pool "bcs' ~ S ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "bcs' ~ S ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 // Serialize is modeled as an uninterpreted function, with an additional
 // axiom to say it's an injection.
 
@@ -1749,7 +1749,7 @@ axiom (forall {{VPOOL}}v: int :: {$1_bcs_serialize'address'(v)}
 {% macro event_module(instance) %}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}
-{%- set VPOOL = '{:pool "event' ~ S ~ '"} ' -%}
+{%- if instance.has_pool -%}{%- set VPOOL = '{:pool "event' ~ S ~ '"} ' -%}{%- else -%}{%- set VPOOL = '' -%}{%- endif -%}
 
 // Map type specific handle to universal one.
 type $1_event_EventHandle{{S}} = $1_event_EventHandle;

--- a/crates/move-prover-boogie-backend/src/boogie_backend/prelude/native.bpl
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/prelude/native.bpl
@@ -24,6 +24,7 @@ function $IsValid'$1_option_Option{{S}}'(opt: $1_option_Option{{S}}): bool {
 {% macro vector_module(instance) %}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}
+{%- set VPOOL = '{:pool "vec' ~ S ~ '"} ' -%}
 {%- if options.native_equality -%}
 {# Whole vector has native equality #}
 function {:inline} $IsEqual'vec{{S}}'(v1: Vec ({{T}}), v2: Vec ({{T}})): bool {
@@ -78,7 +79,7 @@ function {:inline} $ContainsVec{{S}}(v: Vec ({{T}}), e: {{T}}): bool {
 }
 
 function $IndexOfVec{{S}}(v: Vec ({{T}}), e: {{T}}): int;
-axiom (forall v: Vec ({{T}}), e: {{T}}:: {$IndexOfVec{{S}}(v, e)}
+axiom (forall {{VPOOL}}v: Vec ({{T}}), e: {{T}}:: {$IndexOfVec{{S}}(v, e)}
     (var i := $IndexOfVec{{S}}(v, e);
      if (!$ContainsVec{{S}}(v, e)) then i == -1
      else $IsValid'u64'(i) && InRangeVec(v, i) && $IsEqual{{S}}(ReadVec(v, i), e) &&
@@ -424,44 +425,44 @@ function $0_vec_$sum{{S}}(v: Vec ({{T}}), start: int, end: int): {{T}};
 {# Different axioms for bit vectors #}
 
 // the sum over an empty range is zero
-axiom (forall v: Vec ({{T}}), start: int, end: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), start: int, end: int ::
       { $0_vec_$sum{{S}}(v, start, end)}
    (start >= end ==> $0_vec_$sum{{S}}(v, start, end) == 0bv{{instance.bit_width}}));
 
 // the sum of a range can be split in two
-axiom (forall v: Vec ({{T}}), a: int, b: int, c: int, d: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), a: int, b: int, c: int, d: int ::
   { $0_vec_$sum{{S}}(v, a, b), $0_vec_$sum{{S}}(v, c, d) }
   0 <= a && a <= b && b == c && c <= d && d <= LenVec(v)  ==>
     $Add'Bv{{instance.bit_width}}'($0_vec_$sum{{S}}(v, a, b), $0_vec_$sum{{S}}(v, c, d)) == $0_vec_$sum{{S}}(v, a, d)) ;
 
 // the sum over a singleton range is the vector element there
-axiom (forall v: Vec ({{T}}), a: int, x: int, y: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), a: int, x: int, y: int ::
   { $0_vec_$sum{{S}}(v, x, y), v->v[a] } // in a proof involving 0_vec_sum(v,...) and v[a]
   0 <= a && a < LenVec(v) ==> $0_vec_$sum{{S}}(v, a, a+1) == v->v[a]);
 
 {%- if instance.is_unsigned %}
 // for vectors nested ranges have sums bounded by the larger (unsigned elements)
-axiom (forall v: Vec ({{T}}), a: int, b: int, c: int, d: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), a: int, b: int, c: int, d: int ::
   { $0_vec_$sum{{S}}(v, a, d), $0_vec_$sum{{S}}(v, b, c) }
   $IsValid'vec{{S}}'(v) && 0 <= a && a <= b && b <= c && c <= d && d <= LenVec(v)  ==>
     $Le'Bv{{instance.bit_width}}'($0_vec_$sum{{S}}(v, b, c), $0_vec_$sum{{S}}(v, a, d)));
 {%- endif %}
 
 // equal vectors have equal sums over the same range
-axiom (forall u: Vec({{T}}), v: Vec({{T}}), from: int, to: int ::
+axiom (forall {{VPOOL}}u: Vec({{T}}), v: Vec({{T}}), from: int, to: int ::
   {$0_vec_$sum{{S}}(u, from, to), $0_vec_$sum{{S}}(v, from, to)}
   $IsEqual'vec{{S}}'(u, v) &&
    0 <= from && from <= to && to <= LenVec(u) ==>
    $0_vec_$sum{{S}}(u, from, to) == $0_vec_$sum{{S}}(v, from, to));
 
 // left-step — compound trigger
-axiom (forall v: Vec ({{T}}), start: int, end: int, next_start: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), start: int, end: int, next_start: int ::
   {$0_vec_$sum{{S}}(v, start, end), $0_vec_$sum{{S}}(v, next_start, end)}
   next_start == start + 1 && start < end ==>
     $0_vec_$sum{{S}}(v, start, end) == $Add'Bv{{instance.bit_width}}'(v->v[start], $0_vec_$sum{{S}}(v, next_start, end)));
 
 // right-step — compound trigger
-axiom (forall v: Vec ({{T}}), start: int, end: int, prev_end: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), start: int, end: int, prev_end: int ::
   {$0_vec_$sum{{S}}(v, start, end), $0_vec_$sum{{S}}(v, start, prev_end)}
   prev_end + 1 == end && start < end ==>
     $0_vec_$sum{{S}}(v, start, end) == $Add'Bv{{instance.bit_width}}'($0_vec_$sum{{S}}(v, start, prev_end), v->v[prev_end]));
@@ -469,44 +470,44 @@ axiom (forall v: Vec ({{T}}), start: int, end: int, prev_end: int ::
 {%- else -%}
 
 // the sum over an empty range is zero
-axiom (forall v: Vec ({{T}}), start: int, end: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), start: int, end: int ::
       { $0_vec_$sum{{S}}(v, start, end)}
    (start >= end ==> $0_vec_$sum{{S}}(v, start, end) == 0));
 
 // the sum of a range can be split in two
-axiom (forall v: Vec ({{T}}), a: int, b: int, c: int, d: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), a: int, b: int, c: int, d: int ::
   { $0_vec_$sum{{S}}(v, a, b), $0_vec_$sum{{S}}(v, c, d) }
   0 <= a && a <= b && b == c && c <= d && d <= LenVec(v)  ==>
     $0_vec_$sum{{S}}(v, a, b) + $0_vec_$sum{{S}}(v, c, d) ==  $0_vec_$sum{{S}}(v, a, d)) ;
 
 // the sum over a singleton range is the vector element there
-axiom (forall v: Vec ({{T}}), a: int, x: int, y: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), a: int, x: int, y: int ::
   { $0_vec_$sum{{S}}(v, x, y), v->v[a] } // in a proof involving 0_vec_sum(v,...) and v[a]
   0 <= a && a < LenVec(v)  ==> $0_vec_$sum{{S}}(v, a, a+1) == v->v[a]);
 
 {%- if instance.is_unsigned %}
 // for vectors nested ranges have sums bounded by the larger (unsigned elements)
-axiom (forall v: Vec ({{T}}), a: int, b: int, c: int, d: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), a: int, b: int, c: int, d: int ::
   { $0_vec_$sum{{S}}(v, a, d), $0_vec_$sum{{S}}(v, b, c) }
   $IsValid'vec{{S}}'(v) && 0 <= a && a <= b && b <= c && c <= d && d <= LenVec(v)  ==>
     $0_vec_$sum{{S}}(v, b, c) <= $0_vec_$sum{{S}}(v, a, d));
 {%- endif %}
 
 // equal vectors have equal sums over the same range
-axiom (forall u: Vec({{T}}), v: Vec({{T}}), from: int, to: int ::
+axiom (forall {{VPOOL}}u: Vec({{T}}), v: Vec({{T}}), from: int, to: int ::
   {$0_vec_$sum{{S}}(u, from, to), $0_vec_$sum{{S}}(v, from, to)}
   $IsEqual'vec{{S}}'(u, v) &&
    0 <= from && from <= to && to <= LenVec(u) ==>
    $0_vec_$sum{{S}}(u, from, to) == $0_vec_$sum{{S}}(v, from, to));
 
 // left-step — compound trigger
-axiom (forall v: Vec ({{T}}), start: int, end: int, next_start: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), start: int, end: int, next_start: int ::
   {$0_vec_$sum{{S}}(v, start, end), $0_vec_$sum{{S}}(v, next_start, end)}
   next_start == start + 1 && start < end ==>
     $0_vec_$sum{{S}}(v, start, end) == v->v[start] + $0_vec_$sum{{S}}(v, next_start, end));
 
 // right-step — compound trigger
-axiom (forall v: Vec ({{T}}), start: int, end: int, prev_end: int ::
+axiom (forall {{VPOOL}}v: Vec ({{T}}), start: int, end: int, prev_end: int ::
   {$0_vec_$sum{{S}}(v, start, end), $0_vec_$sum{{S}}(v, start, prev_end)}
   prev_end + 1 == end && start < end ==>
     $0_vec_$sum{{S}}(v, start, end) == $0_vec_$sum{{S}}(v, start, prev_end) + v->v[prev_end]);
@@ -533,6 +534,7 @@ function {:inline} $0_vector_iter_sum_range{{S}}(v: Vec ({{T}}), start: int, end
 {% macro vec_set_module(instance) %}
 {%- set T = instance.name -%}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
+{%- set VPOOL = '{:pool "vec_set' ~ S ~ '"} ' -%}
 
 procedure {:inline 1} $2_vec_set_get_idx_opt{{S}}(
     s: $2_vec_set_VecSet{{S}},
@@ -606,6 +608,7 @@ function {:inline} $2_vec_set_remove_pure{{S}}(s: $2_vec_set_VecSet{{S}}, k: {{T
 {%- set T = instance.name -%}
 {%- set T_S = instance.suffix -%}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
+{%- set VPOOL = '{:pool "table_vec' ~ S ~ '"} ' -%}
 
 function $IsValid'$2_table_vec_TableVec{{S}}'(s: $2_table_vec_TableVec{{S}}): bool {
     $IsValid'$2_table_Table'u64_{{T_S}}''(s->$contents) &&
@@ -624,26 +627,27 @@ function $IsValid'$2_table_vec_TableVec{{S}}'(s: $2_table_vec_TableVec{{S}}): bo
 {%- set K_S = "'" ~ key_instance.suffix ~ "'" -%}
 {%- set V_S = "'" ~ value_instance.suffix ~ "'" -%}
 {%- set S = "'" ~ key_instance.suffix ~ "_" ~ value_instance.suffix ~ "'" -%}
+{%- set VPOOL = '{:pool "vec_map' ~ S ~ '"} ' -%}
 
 function {:inline} $ContainsVecMap{{S}}(v: Vec ($2_vec_map_Entry{{S}}), k: {{K}}): bool {
     (exists i: int :: $IsValid'u64'(i) && InRangeVec(v, i) && $IsEqual{{K_S}}(ReadVec(v, i)->$key, k))
 }
 
 function $IndexOfVecMap{{S}}(v: Vec ($2_vec_map_Entry{{S}}), k: {{K}}): int;
-axiom (forall v: Vec ($2_vec_map_Entry{{S}}), k: {{K}} :: {$IndexOfVecMap{{S}}(v, k)}
+axiom (forall {{VPOOL}}v: Vec ($2_vec_map_Entry{{S}}), k: {{K}} :: {$IndexOfVecMap{{S}}(v, k)}
     (var i := $IndexOfVecMap{{S}}(v, k);
      if (!$ContainsVecMap{{S}}(v, k)) then i == -1
      else $IsValid'u64'(i) && InRangeVec(v, i) && $IsEqual{{K_S}}(ReadVec(v, i)->$key, k) &&
         (forall j: int :: $IsValid'u64'(j) && j >= 0 && j < i ==> !$IsEqual{{K_S}}(ReadVec(v, j)->$key, k))));
 
 function $VecMapKeys{{S}}(v: Vec ($2_vec_map_Entry{{S}})): Vec ({{K}});
-axiom (forall v: Vec ($2_vec_map_Entry{{S}}) :: {$VecMapKeys{{S}}(v)}
+axiom (forall {{VPOOL}}v: Vec ($2_vec_map_Entry{{S}}) :: {$VecMapKeys{{S}}(v)}
     (var keys := $VecMapKeys{{S}}(v);
      LenVec(keys) == LenVec(v) &&
      (forall i: int :: InRangeVec(v, i) ==> $IsEqual{{K_S}}(ReadVec(keys, i), ReadVec(v, i)->$key))));
 
 function $VecMapValues{{S}}(v: Vec ($2_vec_map_Entry{{S}})): Vec ({{V}});
-axiom (forall v: Vec ($2_vec_map_Entry{{S}}) :: {$VecMapValues{{S}}(v)}
+axiom (forall {{VPOOL}}v: Vec ($2_vec_map_Entry{{S}}) :: {$VecMapValues{{S}}(v)}
     (var values := $VecMapValues{{S}}(v);
      LenVec(values) == LenVec(v) &&
      (forall i: int :: InRangeVec(v, i) ==> $IsEqual{{V_S}}(ReadVec(values, i), ReadVec(v, i)->$value))));
@@ -663,7 +667,7 @@ function $DisjointVecMap{{S}}(v: Vec ($2_vec_map_Entry{{S}})): bool {
 }
 
 function $VecMapFromKeysValues{{S}}(keys: Vec ({{K}}), values: Vec ({{V}})): Vec ($2_vec_map_Entry{{S}});
-axiom (forall keys: Vec ({{K}}), values: Vec ({{V}}) :: {$VecMapFromKeysValues{{S}}(keys, values)}
+axiom (forall {{VPOOL}}keys: Vec ({{K}}), values: Vec ({{V}}) :: {$VecMapFromKeysValues{{S}}(keys, values)}
     (var entries := $VecMapFromKeysValues{{S}}(keys, values);
      LenVec(entries) == LenVec(keys) &&
      (forall i: int :: InRangeVec(keys, i) ==>
@@ -783,10 +787,11 @@ function {:inline} $2_vec_map_remove_pure{{S}}(vm: $2_vec_map_VecMap{{S}}, key: 
 {% macro table_key_encoding(instance) %}
 {%- set K = instance.name -%}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
+{%- set VPOOL = '{:pool "table_key' ~ S ~ '"} ' -%}
 
 function $EncodeKey{{S}}(k: {{K}}): int;
 axiom (
-  forall k1, k2: {{K}} :: {$EncodeKey{{S}}(k1), $EncodeKey{{S}}(k2)}
+  forall {{VPOOL}}k1, k2: {{K}} :: {$EncodeKey{{S}}(k1), $EncodeKey{{S}}(k2)}
     $IsEqual{{S}}(k1, k2) <==> $EncodeKey{{S}}(k1) == $EncodeKey{{S}}(k2)
 );
 {% endmacro table_key_encoding %}
@@ -796,6 +801,7 @@ axiom (
 {%- set Self = "Table int (" ~ V ~ ")" -%}
 {%- set S = "'" ~ "Table" ~ "'" ~ "int" ~ "_" ~ instance.suffix ~ "'" ~ "'" -%}
 {%- set SV = "'" ~ instance.suffix ~ "'" -%}
+{%- set VPOOL = '{:pool "table' ~ SV ~ '"} ' -%}
 
 {%- if options.native_equality -%}
 function $IsEqual'{{S}}'(t1: {{Self}}, t2: {{Self}}): bool {
@@ -826,6 +832,7 @@ function $IsValid'{{S}}'(t: {{Self}}): bool {
 {%- set S = "'" ~ instance.0.suffix ~ "_" ~ instance.1.suffix ~ "'" -%}
 {%- set SV = "'" ~ instance.1.suffix ~ "'" -%}
 {%- set ENC = "$EncodeKey'" ~ instance.0.suffix ~ "'" -%}
+{%- set VPOOL = '{:pool "table' ~ S ~ '"} ' -%}
 
 datatype {{Type}}{{S}} {
     {{Type}}{{S}}($id: $2_object_UID, $contents: {{Self}})
@@ -997,6 +1004,7 @@ procedure {:inline 2} {{impl.fun_drop}}{{S}}(t: {{Type}}{{S}}) {}
 {%- set SV = "'" ~ instance.1.suffix ~ "'" -%}
 {%- set DF_S = "'" ~ instance.0.suffix ~ "_" ~ instance.1.suffix ~ "_" ~ impl.struct_name ~ "'" -%}
 {%- set ENC = "$EncodeKey'" ~ instance.0.suffix ~ "'" -%}
+{%- set VPOOL = '{:pool "df' ~ S ~ '"} ' -%}
 
 {%- if impl.fun_add != "" %}
 procedure {:inline 2} {{impl.fun_add}}{{DF_S}}(m: $Mutation ({{Type}}), k: {{K}}, v: {{V}}) returns (m': $Mutation({{Type}})) {
@@ -1101,7 +1109,7 @@ function {:inline} {{impl.fun_exists_with_type}}{{DF_S}}(t: ({{Type}}), k: {{K}}
 {%- endif %}
 
 {%- if impl.fun_exists != "" %}
-axiom (forall t: {{Type}}, k: {{K}} :: {({{impl.fun_exists_inner}}{{SK}}(t, k))}
+axiom (forall {{VPOOL}}t: {{Type}}, k: {{K}} :: {({{impl.fun_exists_inner}}{{SK}}(t, k))}
    ContainsTable(t->$dynamic_fields{{S}}, {{ENC}}(k)) ==> {{impl.fun_exists_inner}}{{SK}}(t, k));
 {%- endif %}
 
@@ -1234,6 +1242,8 @@ axiom (forall t: {{Type}}, k: {{K}} :: {({{impl.fun_exists_inner}}{{SK}}(t, k))}
 {%- set QP = instance.quantifier_params -%}
 {%- set QA = instance.quantifier_args -%}
 {%- set FN = instance.name -%}
+{%- set PID = instance.pool_id -%}
+{%- if instance.has_pool -%}{%- set POOL = '{:pool "' ~ instance.qht ~ '-' ~ PID ~ '"} ' -%}{%- else -%}{%- set POOL = '' -%}{%- endif -%}
 {%- set RT = instance.result_type -%}
 {%- set EAA = instance.extra_args_after -%}
 {%- if instance.extra_args_before == "" -%}
@@ -1248,12 +1258,12 @@ axiom (forall t: {{Type}}, k: {{K}} :: {({{impl.fun_exists_inner}}{{SK}}(t, k))}
 function $FindIndicesQuantifierHelper_{{FN}}({{QP}}): Vec ({{RT}});
 {%- if instance.input_vec_is_equal_suffix != "" %}
 // congruence: $IsEqual inputs give equal results
-axiom (forall {{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$FindIndicesQuantifierHelper_{{FN}}({{QA}}), $FindIndicesQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
+axiom (forall {{POOL}}{{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$FindIndicesQuantifierHelper_{{FN}}({{QA}}), $FindIndicesQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
     $IsEqual'{{instance.input_vec_is_equal_suffix}}'(v, v2) ==>
         $FindIndicesQuantifierHelper_{{FN}}({{QA}}) == $FindIndicesQuantifierHelper_{{FN}}(v2, start, end{{CAT}})
 );
 {%- endif %}
-axiom (forall {{QP}} :: {$FindIndicesQuantifierHelper_{{FN}}({{QA}})}
+axiom (forall {{POOL}}{{QP}} :: {$FindIndicesQuantifierHelper_{{FN}}({{QA}})}
 (
     var res := $FindIndicesQuantifierHelper_{{FN}}({{QA}});
         $IsValid'{{instance.result_is_valid_suffix}}'(res) &&
@@ -1266,13 +1276,13 @@ axiom (forall {{QP}} :: {$FindIndicesQuantifierHelper_{{FN}}({{QA}})}
     )
 );
 // strict ordering — separate trigger so it only fires when comparing elements
-axiom (forall {{QP}}, k: int, l: int ::
+axiom (forall {{POOL}}{{QP}}, k: int, l: int ::
     {ReadVec($FindIndicesQuantifierHelper_{{FN}}({{QA}}), k), ReadVec($FindIndicesQuantifierHelper_{{FN}}({{QA}}), l)}
     0 <= k && k < l && l < LenVec($FindIndicesQuantifierHelper_{{FN}}({{QA}})) ==>
         ReadVec($FindIndicesQuantifierHelper_{{FN}}({{QA}}), k) < ReadVec($FindIndicesQuantifierHelper_{{FN}}({{QA}}), l)
 );
 // end-step — compound trigger prevents matching loops
-axiom (forall {{QP}}, prev_end: int ::
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
     {$FindIndicesQuantifierHelper_{{FN}}({{QA}}), $FindIndicesQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}})}
     prev_end + 1 == end && start < end ==>
     (var res := $FindIndicesQuantifierHelper_{{FN}}({{QA}});
@@ -1286,7 +1296,7 @@ axiom (forall {{QP}}, prev_end: int ::
     ))
 );
 // start-step — compound trigger, mirror of end-step
-axiom (forall {{QP}}, next_start: int ::
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
     {$FindIndicesQuantifierHelper_{{FN}}({{QA}}), $FindIndicesQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})}
     next_start == start + 1 && start < end ==>
     (var res := $FindIndicesQuantifierHelper_{{FN}}({{QA}});
@@ -1305,12 +1315,12 @@ axiom (forall {{QP}}, next_start: int ::
 function $FilterQuantifierHelper_{{FN}}({{QP}}): Vec ({{RT}});
 {%- if instance.input_vec_is_equal_suffix != "" %}
 // congruence
-axiom (forall {{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$FilterQuantifierHelper_{{FN}}({{QA}}), $FilterQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
+axiom (forall {{POOL}}{{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$FilterQuantifierHelper_{{FN}}({{QA}}), $FilterQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
     $IsEqual'{{instance.input_vec_is_equal_suffix}}'(v, v2) ==>
         $FilterQuantifierHelper_{{FN}}({{QA}}) == $FilterQuantifierHelper_{{FN}}(v2, start, end{{CAT}})
 );
 {%- endif %}
-axiom (forall {{QP}} :: {$FilterQuantifierHelper_{{FN}}({{QA}})}
+axiom (forall {{POOL}}{{QP}} :: {$FilterQuantifierHelper_{{FN}}({{QA}})}
 (
     var res := $FilterQuantifierHelper_{{FN}}({{QA}});
         $IsValid'{{instance.result_is_valid_suffix}}'(res) &&
@@ -1325,7 +1335,7 @@ axiom (forall {{QP}} :: {$FilterQuantifierHelper_{{FN}}({{QA}})}
     )
 );
 // end-step — compound trigger
-axiom (forall {{QP}}, prev_end: int ::
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
     {$FilterQuantifierHelper_{{FN}}({{QA}}), $FilterQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}})}
     prev_end + 1 == end && start < end ==>
     (var res := $FilterQuantifierHelper_{{FN}}({{QA}});
@@ -1339,7 +1349,7 @@ axiom (forall {{QP}}, prev_end: int ::
     ))
 );
 // start-step — compound trigger
-axiom (forall {{QP}}, next_start: int ::
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
     {$FilterQuantifierHelper_{{FN}}({{QA}}), $FilterQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})}
     next_start == start + 1 && start < end ==>
     (var res := $FilterQuantifierHelper_{{FN}}({{QA}});
@@ -1357,12 +1367,12 @@ axiom (forall {{QP}}, next_start: int ::
 {%- if instance.qht == "find_index" %}
 function $FindIndexQuantifierHelper_{{FN}}({{QP}}): int;
 {%- if instance.input_vec_is_equal_suffix != "" %}
-axiom (forall {{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$FindIndexQuantifierHelper_{{FN}}({{QA}}), $FindIndexQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
+axiom (forall {{POOL}}{{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$FindIndexQuantifierHelper_{{FN}}({{QA}}), $FindIndexQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
     $IsEqual'{{instance.input_vec_is_equal_suffix}}'(v, v2) ==>
         $FindIndexQuantifierHelper_{{FN}}({{QA}}) == $FindIndexQuantifierHelper_{{FN}}(v2, start, end{{CAT}})
 );
 {%- endif %}
-axiom (forall {{QP}} :: {$FindIndexQuantifierHelper_{{FN}}({{QA}})}
+axiom (forall {{POOL}}{{QP}} :: {$FindIndexQuantifierHelper_{{FN}}({{QA}})}
 (
     var res := $FindIndexQuantifierHelper_{{FN}}({{QA}});
         if (forall i: int :: start <= i && i < end ==> !{{FN}}({{EAB}}ReadVec(v, i){{EAA}})) then res == -1
@@ -1371,7 +1381,7 @@ axiom (forall {{QP}} :: {$FindIndexQuantifierHelper_{{FN}}({{QA}})}
     )
 );
 // end-step — compound trigger
-axiom (forall {{QP}}, prev_end: int ::
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
     {$FindIndexQuantifierHelper_{{FN}}({{QA}}), $FindIndexQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}})}
     prev_end + 1 == end && start < end ==>
     (var prev := $FindIndexQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}});
@@ -1381,7 +1391,7 @@ axiom (forall {{QP}}, prev_end: int ::
              else -1))
 );
 // start-step — compound trigger
-axiom (forall {{QP}}, next_start: int ::
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
     {$FindIndexQuantifierHelper_{{FN}}({{QA}}), $FindIndexQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})}
     next_start == start + 1 && start < end ==>
         $FindIndexQuantifierHelper_{{FN}}({{QA}}) ==
@@ -1393,12 +1403,12 @@ axiom (forall {{QP}}, next_start: int ::
 {%- if instance.qht == "map" %}
 function $MapQuantifierHelper_{{FN}}({{QP}}): Vec ({{RT}});
 {%- if instance.input_vec_is_equal_suffix != "" %}
-axiom (forall {{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$MapQuantifierHelper_{{FN}}({{QA}}), $MapQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
+axiom (forall {{POOL}}{{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$MapQuantifierHelper_{{FN}}({{QA}}), $MapQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
     $IsEqual'{{instance.input_vec_is_equal_suffix}}'(v, v2) ==>
         $MapQuantifierHelper_{{FN}}({{QA}}) == $MapQuantifierHelper_{{FN}}(v2, start, end{{CAT}})
 );
 {%- endif %}
-axiom (forall {{QP}}:: {$MapQuantifierHelper_{{FN}}({{QA}})}
+axiom (forall {{POOL}}{{QP}}:: {$MapQuantifierHelper_{{FN}}({{QA}})}
 (
     var res := $MapQuantifierHelper_{{FN}}({{QA}});
         $IsValid'{{instance.result_is_valid_suffix}}'(res) &&
@@ -1408,7 +1418,7 @@ axiom (forall {{QP}}:: {$MapQuantifierHelper_{{FN}}({{QA}})}
     )
 );
 // end-step — compound trigger
-axiom (forall {{QP}}, prev_end: int ::
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
     {$MapQuantifierHelper_{{FN}}({{QA}}), $MapQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}})}
     prev_end + 1 == end && start < end ==>
     (var res := $MapQuantifierHelper_{{FN}}({{QA}});
@@ -1419,7 +1429,7 @@ axiom (forall {{QP}}, prev_end: int ::
     ))
 );
 // start-step — compound trigger
-axiom (forall {{QP}}, next_start: int ::
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
     {$MapQuantifierHelper_{{FN}}({{QA}}), $MapQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})}
     next_start == start + 1 && start < end ==>
     (var res := $MapQuantifierHelper_{{FN}}({{QA}});
@@ -1433,7 +1443,7 @@ axiom (forall {{QP}}, next_start: int ::
 
 {%- if instance.qht == "range_map" %}
 function $RangeMapQuantifierHelper_{{FN}}({{QP}}): Vec ({{RT}});
-axiom (forall {{QP}}:: {$RangeMapQuantifierHelper_{{FN}}({{QA}})}
+axiom (forall {{POOL}}{{QP}}:: {$RangeMapQuantifierHelper_{{FN}}({{QA}})}
 (
     var res := $RangeMapQuantifierHelper_{{FN}}({{QA}});
         $IsValid'{{instance.result_is_valid_suffix}}'(res) &&
@@ -1443,7 +1453,7 @@ axiom (forall {{QP}}:: {$RangeMapQuantifierHelper_{{FN}}({{QA}})}
     )
 );
 // end-step — compound trigger
-axiom (forall {{QP}}, prev_end: int ::
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
     {$RangeMapQuantifierHelper_{{FN}}({{QA}}), $RangeMapQuantifierHelper_{{FN}}(start, prev_end{{CAT}})}
     prev_end + 1 == end && start < end ==>
     (var res := $RangeMapQuantifierHelper_{{FN}}({{QA}});
@@ -1454,7 +1464,7 @@ axiom (forall {{QP}}, prev_end: int ::
     ))
 );
 // start-step — compound trigger
-axiom (forall {{QP}}, next_start: int ::
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
     {$RangeMapQuantifierHelper_{{FN}}({{QA}}), $RangeMapQuantifierHelper_{{FN}}(next_start, end{{CAT}})}
     next_start == start + 1 && start < end ==>
     (var res := $RangeMapQuantifierHelper_{{FN}}({{QA}});
@@ -1469,18 +1479,18 @@ axiom (forall {{QP}}, next_start: int ::
 {%- if instance.qht == "count" %}
 function $CountQuantifierHelper_{{FN}}({{QP}}): int;
 {%- if instance.input_vec_is_equal_suffix != "" %}
-axiom (forall {{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$CountQuantifierHelper_{{FN}}({{QA}}), $CountQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
+axiom (forall {{POOL}}{{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$CountQuantifierHelper_{{FN}}({{QA}}), $CountQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
     $IsEqual'{{instance.input_vec_is_equal_suffix}}'(v, v2) ==>
         $CountQuantifierHelper_{{FN}}({{QA}}) == $CountQuantifierHelper_{{FN}}(v2, start, end{{CAT}})
 );
 {%- endif %}
-axiom (forall {{QP}} :: {$CountQuantifierHelper_{{FN}}({{QA}})}
+axiom (forall {{POOL}}{{QP}} :: {$CountQuantifierHelper_{{FN}}({{QA}})}
     0 <= $CountQuantifierHelper_{{FN}}({{QA}}) &&
     $CountQuantifierHelper_{{FN}}({{QA}}) <= (if start <= end then end - start else 0) &&
     (start >= end ==> $CountQuantifierHelper_{{FN}}({{QA}}) == 0)
 );
 // start-step — compound trigger
-axiom (forall {{QP}}, next_start: int ::
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
     {$CountQuantifierHelper_{{FN}}({{QA}}), $CountQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})}
     next_start == start + 1 && start < end ==>
         $CountQuantifierHelper_{{FN}}({{QA}}) ==
@@ -1488,7 +1498,7 @@ axiom (forall {{QP}}, next_start: int ::
             + $CountQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})
 );
 // end-step — compound trigger
-axiom (forall {{QP}}, prev_end: int ::
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
     {$CountQuantifierHelper_{{FN}}({{QA}}), $CountQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}})}
     prev_end + 1 == end && start < end ==>
         $CountQuantifierHelper_{{FN}}({{QA}}) ==
@@ -1496,7 +1506,7 @@ axiom (forall {{QP}}, prev_end: int ::
             + (if {{FN}}({{EAB}}ReadVec(v, prev_end){{EAA}}) then 1 else 0)
 );
 // split — compound trigger on the two sub-range counts
-axiom (forall {{QP}}, split_point: int ::
+axiom (forall {{POOL}}{{QP}}, split_point: int ::
     {$CountQuantifierHelper_{{FN}}(v, start, split_point{{CAT}}), $CountQuantifierHelper_{{FN}}(v, split_point, end{{CAT}})}
     0 <= start && start <= split_point && split_point <= end && end <= LenVec(v) ==>
         $CountQuantifierHelper_{{FN}}(v, start, split_point{{CAT}}) + $CountQuantifierHelper_{{FN}}(v, split_point, end{{CAT}})
@@ -1506,16 +1516,16 @@ axiom (forall {{QP}}, split_point: int ::
 {%- if instance.qht == "sum_map" %}
 function $SumMapQuantifierHelper_{{FN}}({{QP}}): int;
 {%- if instance.input_vec_is_equal_suffix != "" %}
-axiom (forall {{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$SumMapQuantifierHelper_{{FN}}({{QA}}), $SumMapQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
+axiom (forall {{POOL}}{{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$SumMapQuantifierHelper_{{FN}}({{QA}}), $SumMapQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
     $IsEqual'{{instance.input_vec_is_equal_suffix}}'(v, v2) ==>
         $SumMapQuantifierHelper_{{FN}}({{QA}}) == $SumMapQuantifierHelper_{{FN}}(v2, start, end{{CAT}})
 );
 {%- endif %}
-axiom (forall {{QP}} :: {$SumMapQuantifierHelper_{{FN}}({{QA}})}
+axiom (forall {{POOL}}{{QP}} :: {$SumMapQuantifierHelper_{{FN}}({{QA}})}
     start >= end ==> $SumMapQuantifierHelper_{{FN}}({{QA}}) == 0
 );
 // start-step — compound trigger
-axiom (forall {{QP}}, next_start: int ::
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
     {$SumMapQuantifierHelper_{{FN}}({{QA}}), $SumMapQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})}
     next_start == start + 1 && start < end ==>
         $SumMapQuantifierHelper_{{FN}}({{QA}}) ==
@@ -1523,7 +1533,7 @@ axiom (forall {{QP}}, next_start: int ::
             + $SumMapQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})
 );
 // end-step — compound trigger
-axiom (forall {{QP}}, prev_end: int ::
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
     {$SumMapQuantifierHelper_{{FN}}({{QA}}), $SumMapQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}})}
     prev_end + 1 == end && start < end ==>
         $SumMapQuantifierHelper_{{FN}}({{QA}}) ==
@@ -1531,19 +1541,19 @@ axiom (forall {{QP}}, prev_end: int ::
             + {{FN}}({{EAB}}ReadVec(v, prev_end){{EAA}})
 );
 // split — compound trigger on the two sub-range sums
-axiom (forall {{QP}}, split_point: int ::
+axiom (forall {{POOL}}{{QP}}, split_point: int ::
     {$SumMapQuantifierHelper_{{FN}}(v, start, split_point{{CAT}}), $SumMapQuantifierHelper_{{FN}}(v, split_point, end{{CAT}})}
     0 <= start && start <= split_point && split_point <= end && end <= LenVec(v) ==>
         $SumMapQuantifierHelper_{{FN}}(v, start, split_point{{CAT}}) + $SumMapQuantifierHelper_{{FN}}(v, split_point, end{{CAT}})
             == $SumMapQuantifierHelper_{{FN}}({{QA}}));
 // singleton — sum over [a, a+1] equals FN applied to v[a]
-axiom (forall {{QP}}, a: int ::
+axiom (forall {{POOL}}{{QP}}, a: int ::
     {$SumMapQuantifierHelper_{{FN}}({{QA}}), ReadVec(v, a)}
     0 <= a && a < LenVec(v) ==>
         $SumMapQuantifierHelper_{{FN}}(v, a, a+1{{CAT}}) == {{FN}}({{EAB}}ReadVec(v, a){{EAA}}));
 {%- if instance.result_is_unsigned %}
 // bounding — nested range sum <= outer (FN returns unsigned)
-axiom (forall {{QP}}, a: int, b: int ::
+axiom (forall {{POOL}}{{QP}}, a: int, b: int ::
     {$SumMapQuantifierHelper_{{FN}}(v, a, b{{CAT}}), $SumMapQuantifierHelper_{{FN}}({{QA}})}
     $IsValid'{{instance.input_vec_is_equal_suffix}}'(v) &&
     0 <= start && start <= a && a <= b && b <= end && end <= LenVec(v) ==>
@@ -1553,13 +1563,13 @@ axiom (forall {{QP}}, a: int, b: int ::
 
 {%- if instance.qht == "range_count" %}
 function $RangeCountQuantifierHelper_{{FN}}({{QP}}): int;
-axiom (forall {{QP}} :: {$RangeCountQuantifierHelper_{{FN}}({{QA}})}
+axiom (forall {{POOL}}{{QP}} :: {$RangeCountQuantifierHelper_{{FN}}({{QA}})}
     0 <= $RangeCountQuantifierHelper_{{FN}}({{QA}}) &&
     $RangeCountQuantifierHelper_{{FN}}({{QA}}) <= (if start <= end then end - start else 0) &&
     (start >= end ==> $RangeCountQuantifierHelper_{{FN}}({{QA}}) == 0)
 );
 // start-step — compound trigger
-axiom (forall {{QP}}, next_start: int ::
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
     {$RangeCountQuantifierHelper_{{FN}}({{QA}}), $RangeCountQuantifierHelper_{{FN}}(next_start, end{{CAT}})}
     next_start == start + 1 && start < end ==>
         $RangeCountQuantifierHelper_{{FN}}({{QA}}) ==
@@ -1567,7 +1577,7 @@ axiom (forall {{QP}}, next_start: int ::
             + $RangeCountQuantifierHelper_{{FN}}(next_start, end{{CAT}})
 );
 // end-step — compound trigger
-axiom (forall {{QP}}, prev_end: int ::
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
     {$RangeCountQuantifierHelper_{{FN}}({{QA}}), $RangeCountQuantifierHelper_{{FN}}(start, prev_end{{CAT}})}
     prev_end + 1 == end && start < end ==>
         $RangeCountQuantifierHelper_{{FN}}({{QA}}) ==
@@ -1575,7 +1585,7 @@ axiom (forall {{QP}}, prev_end: int ::
             + (if {{FN}}({{EAB}}prev_end{{EAA}}) then 1 else 0)
 );
 // split — compound trigger on the two sub-range counts
-axiom (forall {{QP}}, split_point: int ::
+axiom (forall {{POOL}}{{QP}}, split_point: int ::
     {$RangeCountQuantifierHelper_{{FN}}(start, split_point{{CAT}}), $RangeCountQuantifierHelper_{{FN}}(split_point, end{{CAT}})}
     start <= split_point && split_point <= end ==>
         $RangeCountQuantifierHelper_{{FN}}(start, split_point{{CAT}}) + $RangeCountQuantifierHelper_{{FN}}(split_point, end{{CAT}})
@@ -1584,11 +1594,11 @@ axiom (forall {{QP}}, split_point: int ::
 
 {%- if instance.qht == "range_sum_map" %}
 function $RangeSumMapQuantifierHelper_{{FN}}({{QP}}): int;
-axiom (forall {{QP}} :: {$RangeSumMapQuantifierHelper_{{FN}}({{QA}})}
+axiom (forall {{POOL}}{{QP}} :: {$RangeSumMapQuantifierHelper_{{FN}}({{QA}})}
     start >= end ==> $RangeSumMapQuantifierHelper_{{FN}}({{QA}}) == 0
 );
 // start-step — compound trigger
-axiom (forall {{QP}}, next_start: int ::
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
     {$RangeSumMapQuantifierHelper_{{FN}}({{QA}}), $RangeSumMapQuantifierHelper_{{FN}}(next_start, end{{CAT}})}
     next_start == start + 1 && start < end ==>
         $RangeSumMapQuantifierHelper_{{FN}}({{QA}}) ==
@@ -1596,7 +1606,7 @@ axiom (forall {{QP}}, next_start: int ::
             + $RangeSumMapQuantifierHelper_{{FN}}(next_start, end{{CAT}})
 );
 // end-step — compound trigger
-axiom (forall {{QP}}, prev_end: int ::
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
     {$RangeSumMapQuantifierHelper_{{FN}}({{QA}}), $RangeSumMapQuantifierHelper_{{FN}}(start, prev_end{{CAT}})}
     prev_end + 1 == end && start < end ==>
         $RangeSumMapQuantifierHelper_{{FN}}({{QA}}) ==
@@ -1604,14 +1614,14 @@ axiom (forall {{QP}}, prev_end: int ::
             + {{FN}}({{EAB}}prev_end{{EAA}})
 );
 // split — compound trigger on the two sub-range sums
-axiom (forall {{QP}}, split_point: int ::
+axiom (forall {{POOL}}{{QP}}, split_point: int ::
     {$RangeSumMapQuantifierHelper_{{FN}}(start, split_point{{CAT}}), $RangeSumMapQuantifierHelper_{{FN}}(split_point, end{{CAT}})}
     start <= split_point && split_point <= end ==>
         $RangeSumMapQuantifierHelper_{{FN}}(start, split_point{{CAT}}) + $RangeSumMapQuantifierHelper_{{FN}}(split_point, end{{CAT}})
             == $RangeSumMapQuantifierHelper_{{FN}}({{QA}}));
 {%- if instance.result_is_unsigned %}
 // bounding — nested range sum <= outer (FN returns unsigned)
-axiom (forall {{QP}}, a: int, b: int ::
+axiom (forall {{POOL}}{{QP}}, a: int, b: int ::
     {$RangeSumMapQuantifierHelper_{{FN}}(a, b{{CAT}}), $RangeSumMapQuantifierHelper_{{FN}}({{QA}})}
     start <= a && a <= b && b <= end ==>
         $RangeSumMapQuantifierHelper_{{FN}}(a, b{{CAT}}) <= $RangeSumMapQuantifierHelper_{{FN}}({{QA}}));
@@ -1643,20 +1653,21 @@ function {:inline} {{impl.fun_exists}}{{DF_S}}(t: {{Type}}, k: {{T}}): bool {
 {% macro bcs_module(instance) %}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}
+{%- set VPOOL = '{:pool "bcs' ~ S ~ '"} ' -%}
 // Serialize is modeled as an uninterpreted function, with an additional
 // axiom to say it's an injection.
 
 function $1_bcs_serialize{{S}}(v: {{T}}): Vec int;
 
-axiom (forall v1, v2: {{T}} :: {$1_bcs_serialize{{S}}(v1), $1_bcs_serialize{{S}}(v2)}
+axiom (forall {{VPOOL}}v1, v2: {{T}} :: {$1_bcs_serialize{{S}}(v1), $1_bcs_serialize{{S}}(v2)}
    $IsEqual{{S}}(v1, v2) <==> $IsEqual'vec'u8''($1_bcs_serialize{{S}}(v1), $1_bcs_serialize{{S}}(v2)));
 
 // This says that serialize returns a non-empty vec<u8>
 {% if options.serialize_bound == 0 %}
-axiom (forall v: {{T}} :: {$1_bcs_serialize{{S}}(v)}
+axiom (forall {{VPOOL}}v: {{T}} :: {$1_bcs_serialize{{S}}(v)}
      ( var r := $1_bcs_serialize{{S}}(v); $IsValid'vec'u8''(r) && LenVec(r) > 0 ));
 {% else %}
-axiom (forall v: {{T}} :: {$1_bcs_serialize{{S}}(v)}
+axiom (forall {{VPOOL}}v: {{T}} :: {$1_bcs_serialize{{S}}(v)}
      ( var r := $1_bcs_serialize{{S}}(v); $IsValid'vec'u8''(r) && LenVec(r) > 0 &&
                             LenVec(r) <= {{options.serialize_bound}} ));
 {% endif %}
@@ -1669,7 +1680,7 @@ function {:inline} $1_bcs_to_bytes{{S}}(v: {{T}}): Vec int {
 // Serialized addresses should have the same length.
 const $serialized_address_len: int;
 // Serialized addresses should have the same length
-axiom (forall v: int :: {$1_bcs_serialize'address'(v)}
+axiom (forall {{VPOOL}}v: int :: {$1_bcs_serialize'address'(v)}
      ( var r := $1_bcs_serialize'address'(v); LenVec(r) == $serialized_address_len));
 {% endif %}
 {% endmacro bcs_module %}
@@ -1680,6 +1691,7 @@ axiom (forall v: int :: {$1_bcs_serialize'address'(v)}
 {% macro event_module(instance) %}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}
+{%- set VPOOL = '{:pool "event' ~ S ~ '"} ' -%}
 
 // Map type specific handle to universal one.
 type $1_event_EventHandle{{S}} = $1_event_EventHandle;
@@ -1694,7 +1706,7 @@ function $IsValid'$1_event_EventHandle{{S}}'(h: $1_event_EventHandle{{S}}): bool
 
 // Embed event `{{T}}` into universal $EventRep
 function {:constructor} $ToEventRep{{S}}(e: {{T}}): $EventRep;
-axiom (forall v1, v2: {{T}} :: {$ToEventRep{{S}}(v1), $ToEventRep{{S}}(v2)}
+axiom (forall {{VPOOL}}v1, v2: {{T}} :: {$ToEventRep{{S}}(v1), $ToEventRep{{S}}(v2)}
     $IsEqual{{S}}(v1, v2) <==> $ToEventRep{{S}}(v1) == $ToEventRep{{S}}(v2));
 
 // Creates a new event handle. This ensures each time it is called that a unique new abstract event handler is

--- a/crates/move-prover-boogie-backend/src/boogie_backend/prelude/native.bpl
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/prelude/native.bpl
@@ -1628,6 +1628,64 @@ axiom (forall {{POOL}}{{QP}}, a: int, b: int ::
 {%- endif %}
 {%- endif %}
 
+{%- if instance.qht == "all" %}
+function $AllQuantifierHelper_{{FN}}({{QP}}): bool;
+{%- if instance.input_vec_is_equal_suffix != "" %}
+axiom (forall {{POOL}}{{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$AllQuantifierHelper_{{FN}}({{QA}}), $AllQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
+    $IsEqual'{{instance.input_vec_is_equal_suffix}}'(v, v2) ==>
+        $AllQuantifierHelper_{{FN}}({{QA}}) == $AllQuantifierHelper_{{FN}}(v2, start, end{{CAT}})
+);
+{%- endif %}
+// soundness: connects helper to the full forall
+axiom (forall {{POOL}}{{QP}} :: {$AllQuantifierHelper_{{FN}}({{QA}})}
+    $AllQuantifierHelper_{{FN}}({{QA}}) <==>
+        (start >= end || (forall i: int :: start <= i && i < end ==> {{FN}}({{EAB}}ReadVec(v, i){{EAA}})))
+);
+// start-step — compound trigger
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
+    {$AllQuantifierHelper_{{FN}}({{QA}}), $AllQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})}
+    next_start == start + 1 && start < end ==>
+        ($AllQuantifierHelper_{{FN}}({{QA}}) ==
+            ({{FN}}({{EAB}}ReadVec(v, start){{EAA}}) && $AllQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})))
+);
+// end-step — compound trigger
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
+    {$AllQuantifierHelper_{{FN}}({{QA}}), $AllQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}})}
+    prev_end + 1 == end && start < end ==>
+        ($AllQuantifierHelper_{{FN}}({{QA}}) ==
+            ($AllQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}}) && {{FN}}({{EAB}}ReadVec(v, prev_end){{EAA}})))
+);
+{%- endif %}
+
+{%- if instance.qht == "any" %}
+function $AnyQuantifierHelper_{{FN}}({{QP}}): bool;
+{%- if instance.input_vec_is_equal_suffix != "" %}
+axiom (forall {{POOL}}{{QP}}, v2: Vec ({{instance.input_elem_type}}) :: {$AnyQuantifierHelper_{{FN}}({{QA}}), $AnyQuantifierHelper_{{FN}}(v2, start, end{{CAT}})}
+    $IsEqual'{{instance.input_vec_is_equal_suffix}}'(v, v2) ==>
+        $AnyQuantifierHelper_{{FN}}({{QA}}) == $AnyQuantifierHelper_{{FN}}(v2, start, end{{CAT}})
+);
+{%- endif %}
+// soundness: connects helper to the full exists
+axiom (forall {{POOL}}{{QP}} :: {$AnyQuantifierHelper_{{FN}}({{QA}})}
+    $AnyQuantifierHelper_{{FN}}({{QA}}) <==>
+        (start < end && (exists i: int :: start <= i && i < end && {{FN}}({{EAB}}ReadVec(v, i){{EAA}})))
+);
+// start-step — compound trigger
+axiom (forall {{POOL}}{{QP}}, next_start: int ::
+    {$AnyQuantifierHelper_{{FN}}({{QA}}), $AnyQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})}
+    next_start == start + 1 && start < end ==>
+        ($AnyQuantifierHelper_{{FN}}({{QA}}) ==
+            ({{FN}}({{EAB}}ReadVec(v, start){{EAA}}) || $AnyQuantifierHelper_{{FN}}(v, next_start, end{{CAT}})))
+);
+// end-step — compound trigger
+axiom (forall {{POOL}}{{QP}}, prev_end: int ::
+    {$AnyQuantifierHelper_{{FN}}({{QA}}), $AnyQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}})}
+    prev_end + 1 == end && start < end ==>
+        ($AnyQuantifierHelper_{{FN}}({{QA}}) ==
+            ($AnyQuantifierHelper_{{FN}}(v, start, prev_end{{CAT}}) || {{FN}}({{EAB}}ReadVec(v, prev_end){{EAA}})))
+);
+{%- endif %}
+
 {% endmacro quantifier_helpers_module %}
 
 {% macro dynamic_field_key_module(impl, instance) %}

--- a/crates/move-stackless-bytecode/src/stackless_bytecode.rs
+++ b/crates/move-stackless-bytecode/src/stackless_bytecode.rs
@@ -153,6 +153,8 @@ pub enum QuantifierHelperType {
     Filter,
     Count,
     SumMap,
+    All,
+    Any,
 }
 
 impl QuantifierHelperType {
@@ -167,6 +169,8 @@ impl QuantifierHelperType {
             QuantifierHelperType::Filter => "filter",
             QuantifierHelperType::Count => "count",
             QuantifierHelperType::SumMap => "sum_map",
+            QuantifierHelperType::All => "all",
+            QuantifierHelperType::Any => "any",
         }
     }
 
@@ -283,6 +287,8 @@ impl QuantifierType {
             QuantifierType::RangeMap => Some(QuantifierHelperType::RangeMap),
             QuantifierType::RangeCount => Some(QuantifierHelperType::RangeCount),
             QuantifierType::RangeSumMap => Some(QuantifierHelperType::RangeSumMap),
+            QuantifierType::All | QuantifierType::AllRange => Some(QuantifierHelperType::All),
+            QuantifierType::Any | QuantifierType::AnyRange => Some(QuantifierHelperType::Any),
             _ => None,
         }
     }

--- a/crates/move-stackless-bytecode/src/stackless_bytecode.rs
+++ b/crates/move-stackless-bytecode/src/stackless_bytecode.rs
@@ -249,6 +249,20 @@ impl QuantifierType {
         )
     }
 
+    pub fn requires_sum(&self) -> bool {
+        matches!(
+            self,
+            QuantifierType::SumMap
+                | QuantifierType::SumMapRange
+                | QuantifierType::Count
+                | QuantifierType::CountRange
+        )
+    }
+
+    pub fn requires_filter_indices(&self) -> bool {
+        matches!(self, QuantifierType::Filter | QuantifierType::FilterRange)
+    }
+
     pub fn into_quantifier_helper_type(&self) -> Option<QuantifierHelperType> {
         match self {
             QuantifierType::Map | QuantifierType::MapRange => Some(QuantifierHelperType::Map),

--- a/crates/move-stackless-bytecode/src/stackless_bytecode.rs
+++ b/crates/move-stackless-bytecode/src/stackless_bytecode.rs
@@ -243,30 +243,6 @@ impl QuantifierType {
         )
     }
 
-    pub fn is_find_or_find_index(&self) -> bool {
-        matches!(
-            self,
-            QuantifierType::Find
-                | QuantifierType::FindRange
-                | QuantifierType::FindIndex
-                | QuantifierType::FindIndexRange
-        )
-    }
-
-    pub fn requires_sum(&self) -> bool {
-        matches!(
-            self,
-            QuantifierType::SumMap
-                | QuantifierType::SumMapRange
-                | QuantifierType::Count
-                | QuantifierType::CountRange
-        )
-    }
-
-    pub fn requires_filter_indices(&self) -> bool {
-        matches!(self, QuantifierType::Filter | QuantifierType::FilterRange)
-    }
-
     pub fn into_quantifier_helper_type(&self) -> Option<QuantifierHelperType> {
         match self {
             QuantifierType::Map | QuantifierType::MapRange => Some(QuantifierHelperType::Map),

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_all.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_all.fail.move
@@ -1,0 +1,18 @@
+/// Same as pool_all.ok but WITHOUT the pool hint.
+/// Z3 cannot find the counterexample MAX_U64 on its own.
+#[allow(unused)]
+module 0x42::pool_all_fail;
+
+#[spec_only]
+use prover::prover::{forall, ensures};
+
+#[ext(pure)]
+fun is_less_than_max(x: &u64): bool {
+    *x < std::u64::max_value!()
+}
+
+#[spec(prove)]
+fun test_not_all_less_than_max_no_pool() {
+    let result = forall!<u64>(|x| is_less_than_max(x));
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_all.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_all.ok.move
@@ -1,0 +1,19 @@
+/// Pool provides a counterexample for a forall: not all u64 are less than MAX.
+/// The pool term MAX_U64 is the counterexample Z3 needs.
+#[allow(unused)]
+module 0x42::pool_all_ok;
+
+#[spec_only]
+use prover::prover::{forall, ensures, add_quantifier_pool};
+
+#[ext(pure)]
+fun is_less_than_max(x: &u64): bool {
+    *x < std::u64::max_value!()
+}
+
+#[spec(prove)]
+fun test_not_all_less_than_max() {
+    add_quantifier_pool(b"is_less_than_max", std::u64::max_value!());
+    let result = forall!<u64>(|x| is_less_than_max(x));
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_basic.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_basic.fail.move
@@ -1,0 +1,18 @@
+/// Same as pool_basic.ok but WITHOUT the pool hint.
+/// Z3 cannot find a counterexample to disprove forall(x, x > 10) on its own.
+#[allow(unused)]
+module 0x42::pool_basic_fail;
+
+#[spec_only]
+use prover::prover::{forall, ensures};
+
+#[ext(pure)]
+fun gt_10(x: &u64): bool {
+    *x > 10
+}
+
+#[spec(prove)]
+fun test_not_all_gt_10_no_pool() {
+    let result = forall!<u64>(|x| gt_10(x));
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_basic.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_basic.ok.move
@@ -1,0 +1,19 @@
+/// Pool provides a counterexample to disprove a universal: not all u64 are > 10.
+/// The pool term 5 is the counterexample Z3 needs.
+#[allow(unused)]
+module 0x42::pool_basic_ok;
+
+#[spec_only]
+use prover::prover::{forall, ensures, add_quantifier_pool};
+
+#[ext(pure)]
+fun gt_10(x: &u64): bool {
+    *x > 10
+}
+
+#[spec(prove)]
+fun test_not_all_gt_10() {
+    add_quantifier_pool(b"gt_10", 5u64);
+    let result = forall!<u64>(|x| gt_10(x));
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_forall_exists.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_forall_exists.fail.move
@@ -1,0 +1,18 @@
+/// Same as pool_forall_exists.ok but without pool hints.
+#[allow(unused)]
+module 0x42::pool_forall_exists_fail;
+
+#[spec_only]
+use prover::prover::{forall, exists, ensures};
+
+#[ext(pure)]
+fun gt_50(x: &u64): bool {
+    *x > 50
+}
+
+#[spec(prove)]
+fun test_forall_and_exists_no_pool() {
+    let not_all = !forall!<u64>(|x| gt_50(x));
+    let some_exist = exists!<u64>(|x| gt_50(x));
+    ensures(not_all && some_exist);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_forall_exists.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_forall_exists.ok.move
@@ -1,0 +1,21 @@
+/// Pool with both forall and exists quantifiers in the same spec.
+/// The pool provides counterexample 0 for forall and witness 100 for exists.
+#[allow(unused)]
+module 0x42::pool_forall_exists_ok;
+
+#[spec_only]
+use prover::prover::{forall, exists, ensures, add_quantifier_pool};
+
+#[ext(pure)]
+fun gt_50(x: &u64): bool {
+    *x > 50
+}
+
+#[spec(prove)]
+fun test_forall_and_exists() {
+    add_quantifier_pool(b"gt_50", 0u64);
+    add_quantifier_pool(b"gt_50", 100u64);
+    let not_all = !forall!<u64>(|x| gt_50(x));
+    let some_exist = exists!<u64>(|x| gt_50(x));
+    ensures(not_all && some_exist);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_incomplete.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_incomplete.fail.move
@@ -1,0 +1,29 @@
+/// Pool with INCOMPLETE coverage. We want to prove that both
+/// !forall(x, x > 0) AND !forall(x, x < MAX) hold. The pool only
+/// provides 0 (which disproves x > 0 but satisfies x < MAX). Since
+/// the quantifier for x < MAX is replaced with P(0) = true, the
+/// second !forall fails.
+#[allow(unused)]
+module 0x42::pool_incomplete_fail;
+
+#[spec_only]
+use prover::prover::{forall, ensures, add_quantifier_pool};
+
+#[ext(pure)]
+fun is_positive(x: &u64): bool {
+    *x > 0
+}
+
+#[ext(pure)]
+fun is_less_than_max(x: &u64): bool {
+    *x < std::u64::max_value!()
+}
+
+#[spec(prove)]
+fun test_incomplete_pool() {
+    add_quantifier_pool(b"is_positive", 0u64);
+    add_quantifier_pool(b"is_less_than_max", 0u64);
+    let not_all_positive = !forall!<u64>(|x| is_positive(x));
+    let not_all_less = !forall!<u64>(|x| is_less_than_max(x));
+    ensures(not_all_positive && not_all_less);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_multi.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_multi.fail.move
@@ -1,0 +1,18 @@
+/// Same as pool_multi.ok but WITHOUT the pool hint.
+/// Z3 cannot find the counterexample x=0 for both_positive(x, &1) on its own.
+#[allow(unused)]
+module 0x42::pool_multi_fail;
+
+#[spec_only]
+use prover::prover::{forall, ensures};
+
+#[ext(pure)]
+fun both_positive(x: &u64, y: &u64): bool {
+    *x > 0 && *y > 0
+}
+
+#[spec(prove)]
+fun test_pool_multi_no_pool_spec() {
+    let result = forall!<u64>(|x| both_positive(x, &1));
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_multi.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_multi.ok.move
@@ -1,0 +1,18 @@
+#[allow(unused)]
+module 0x42::pool_multi_ok;
+
+#[spec_only]
+use prover::prover::{forall, ensures, add_quantifier_pool};
+
+#[ext(pure)]
+fun both_positive(x: &u64, y: &u64): bool {
+    *x > 0 && *y > 0
+}
+
+/// This test uses multiple add_quantifier_pool calls to add terms to the pool.
+#[spec(prove)]
+fun test_pool_multi_spec() {
+    add_quantifier_pool(b"both_positive", 0u64);
+    let result = forall!<u64>(|x| both_positive(x, &1));
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_needed.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_needed.fail.move
@@ -1,0 +1,18 @@
+#[allow(unused)]
+module 0x42::pool_needed_fail;
+
+#[spec_only]
+use prover::prover::{forall, ensures};
+
+#[ext(pure)]
+fun is_positive(x: &u64): bool {
+    *x > 0
+}
+
+/// This test does NOT use add_quantifier_pool, so the solver cannot instantiate the quantifier.
+/// Without pool hints providing the counterexample (0), verification should fail.
+#[spec(prove)]
+fun test_pool_needed_spec() {
+    let result = forall!<u64>(|x| is_positive(x));
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_needed.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_needed.ok.move
@@ -1,0 +1,18 @@
+#[allow(unused)]
+module 0x42::pool_needed_ok;
+
+#[spec_only]
+use prover::prover::{forall, ensures, add_quantifier_pool};
+
+#[ext(pure)]
+fun is_positive(x: &u64): bool {
+    *x > 0
+}
+
+/// This test uses add_quantifier_pool so the solver can instantiate the quantifier.
+#[spec(prove)]
+fun test_pool_needed_spec() {
+    let result = forall!<u64>(|x| is_positive(x));
+    add_quantifier_pool(b"is_positive", 0u64);
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_wrong_name.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_wrong_name.fail.move
@@ -1,0 +1,23 @@
+/// Pool with the right counterexample value (0) but WRONG name. The pool
+/// name "wrong_name" doesn't match "is_positive", so no {:pool} is attached
+/// to the quantifier and it's NOT dropped. However, the add_to_pool assume
+/// leaks the term 0 into the e-graph. To prevent this from accidentally
+/// helping Z3, we use a term (42) that SATISFIES the predicate — even if
+/// leaked, it can't serve as a counterexample.
+#[allow(unused)]
+module 0x42::pool_wrong_name_fail;
+
+#[spec_only]
+use prover::prover::{forall, ensures, add_quantifier_pool};
+
+#[ext(pure)]
+fun is_positive(x: &u64): bool {
+    *x > 0
+}
+
+#[spec(prove)]
+fun test_wrong_pool_name() {
+    add_quantifier_pool(b"wrong_name", 42u64);
+    let result = forall!<u64>(|x| is_positive(x));
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/inputs/quantifiers/pool_wrong_term.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/pool_wrong_term.fail.move
@@ -1,0 +1,22 @@
+/// Pool with the WRONG term. We want to prove !forall(x, x > 0), which is
+/// true (x=0 is a counterexample). But the pool provides 42 — a value where
+/// the predicate HOLDS. Since Boogie drops the quantifier and replaces it
+/// with the ground instance P(42) = true, the forall "appears" true and
+/// !forall fails.
+#[allow(unused)]
+module 0x42::pool_wrong_term_fail;
+
+#[spec_only]
+use prover::prover::{forall, ensures, add_quantifier_pool};
+
+#[ext(pure)]
+fun is_positive(x: &u64): bool {
+    *x > 0
+}
+
+#[spec(prove)]
+fun test_wrong_pool_term() {
+    add_quantifier_pool(b"is_positive", 42u64);
+    let result = forall!<u64>(|x| is_positive(x));
+    ensures(!result);
+}

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_all.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_all.fail.move.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+exiting with verification errors
+error: prover::ensures does not hold
+   ┌─ tests/inputs/quantifiers/pool_all.fail.move:17:5
+   │
+17 │     ensures(!result);
+   │     ^^^^^^^^^^^^^^^^
+   │
+   =     at tests/inputs/quantifiers/pool_all.fail.move:16: test_not_all_less_than_max_no_pool

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_all.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_all.ok.move.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-prover/tests/integration.rs
+expression: output
+---
+Verification successful

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_basic.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_basic.fail.move.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+exiting with verification errors
+error: prover::ensures does not hold
+   ┌─ tests/inputs/quantifiers/pool_basic.fail.move:17:5
+   │
+17 │     ensures(!result);
+   │     ^^^^^^^^^^^^^^^^
+   │
+   =     at tests/inputs/quantifiers/pool_basic.fail.move:16: test_not_all_gt_10_no_pool

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_basic.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_basic.ok.move.snap
@@ -1,0 +1,6 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+Verification successful

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_forall_exists.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_forall_exists.fail.move.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+exiting with verification errors
+error: prover::ensures does not hold
+   ┌─ tests/inputs/quantifiers/pool_forall_exists.fail.move:17:5
+   │
+17 │     ensures(not_all && some_exist);
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/inputs/quantifiers/pool_forall_exists.fail.move:15: test_forall_and_exists_no_pool

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_forall_exists.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_forall_exists.ok.move.snap
@@ -1,0 +1,6 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+Verification successful

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_incomplete.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_incomplete.fail.move.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+exiting with verification errors
+error: prover::ensures does not hold
+   ┌─ tests/inputs/quantifiers/pool_incomplete.fail.move:28:5
+   │
+28 │     ensures(not_all_positive && not_all_less);
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/inputs/quantifiers/pool_incomplete.fail.move:24: test_incomplete_pool

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_multi.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_multi.fail.move.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+exiting with verification errors
+error: prover::ensures does not hold
+   ┌─ tests/inputs/quantifiers/pool_multi.fail.move:17:5
+   │
+17 │     ensures(!result);
+   │     ^^^^^^^^^^^^^^^^
+   │
+   =     at tests/inputs/quantifiers/pool_multi.fail.move:16: test_pool_multi_no_pool_spec

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_multi.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_multi.ok.move.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-prover/tests/integration.rs
+expression: output
+---
+Verification successful

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_needed.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_needed.fail.move.snap
@@ -1,0 +1,12 @@
+---
+source: crates/sui-prover/tests/integration.rs
+expression: output
+---
+exiting with verification errors
+error: prover::ensures does not hold
+   ┌─ tests/inputs/quantifiers/pool_needed.fail.move:17:5
+   │
+17 │     ensures(!result);
+   │     ^^^^^^^^^^^^^^^^
+   │
+   =     at tests/inputs/quantifiers/pool_needed.fail.move:16: test_pool_needed_spec

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_needed.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_needed.ok.move.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-prover/tests/integration.rs
+expression: output
+---
+Verification successful

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_wrong_name.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_wrong_name.fail.move.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+exiting with verification errors
+error: prover::ensures does not hold
+   ┌─ tests/inputs/quantifiers/pool_wrong_name.fail.move:22:5
+   │
+22 │     ensures(!result);
+   │     ^^^^^^^^^^^^^^^^
+   │
+   =     at tests/inputs/quantifiers/pool_wrong_name.fail.move:20: test_wrong_pool_name

--- a/crates/sui-prover/tests/snapshots/quantifiers/pool_wrong_term.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/quantifiers/pool_wrong_term.fail.move.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+exiting with verification errors
+error: prover::ensures does not hold
+   ┌─ tests/inputs/quantifiers/pool_wrong_term.fail.move:21:5
+   │
+21 │     ensures(!result);
+   │     ^^^^^^^^^^^^^^^^
+   │
+   =     at tests/inputs/quantifiers/pool_wrong_term.fail.move:19: test_wrong_pool_term

--- a/packages/prover/sources/prover.move
+++ b/packages/prover/sources/prover.move
@@ -73,6 +73,9 @@ fun fresh_spec<T>(): T {
 native fun type_inv<T>(x: &T): bool;
 
 #[spec_only]
+public native fun add_quantifier_pool<T>(pool_name: vector<u8>, term: T);
+
+#[spec_only]
 public native fun begin_forall_lambda<T>(): &T;
 #[spec_only]
 public native fun end_forall_lambda(): bool;


### PR DESCRIPTION
…ds, and failing tests

Pool {:pool} annotations are now only emitted on quantifiers when a matching add_quantifier_pool call exists in the same function (substring match on the Boogie function name). Added add_quantifier_pool2 through pool10 overloads for multi-variable pool instantiation. Added pool_needed.fail.move test that verifies pool hints are necessary for certain quantifier proofs.