### PR TITLE
Make type_name module functions pure for use in quantifiers (#530)

### DIFF
--- a/crates/move-model/src/model.rs
+++ b/crates/move-model/src/model.rs
@@ -4073,6 +4073,11 @@ impl GlobalEnv {
             self.sui_tx_context_epoch_timestamp_ms_qid(),
             self.sui_tx_context_reference_gas_price_qid(),
             self.sui_tx_context_gas_price_qid(),
+            // std::type_name native functions
+            self.std_type_name_with_defining_ids_qid(),
+            self.std_type_name_with_original_ids_qid(),
+            self.std_type_name_defining_id_qid(),
+            self.std_type_name_original_id_qid(),
         ]
         .into_iter()
         .filter_map(|x| x)

--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -248,6 +248,64 @@ impl<'env> BoogieTranslator<'env> {
         emitln!(self.writer);
     }
 
+    /// Emit Boogie function declarations for std::type_name native functions.
+    /// These are emitted as uninterpreted functions so they can be used in quantifiers.
+    /// The prover treats them as deterministic (same type always returns the same value).
+    fn emit_type_name_functions(&self, fun_env: &FunctionEnv, mono_info: &MonoInfo) {
+        let qid = fun_env.get_qualified_id();
+        let is_defining_id = self.env.std_type_name_defining_id_qid() == Some(qid)
+            || self.env.std_type_name_original_id_qid() == Some(qid);
+        let is_type_name = self.env.std_type_name_with_defining_ids_qid() == Some(qid)
+            || self.env.std_type_name_with_original_ids_qid() == Some(qid);
+
+        if !is_defining_id && !is_type_name {
+            return;
+        }
+
+        let empty = &BTreeSet::new();
+        for type_inst in mono_info
+            .funs
+            .get(&(qid, FunctionVariant::Baseline))
+            .unwrap_or(empty)
+        {
+            let func_name =
+                boogie_function_name(fun_env, type_inst, FunctionTranslationStyle::Default);
+            let rets = fun_env
+                .get_return_types()
+                .iter()
+                .enumerate()
+                .map(|(idx, ty)| {
+                    let ty = ty.instantiate(type_inst);
+                    format!(
+                        "$ret{}: {}",
+                        idx,
+                        boogie_type(self.env, ty.skip_reference())
+                    )
+                })
+                .join(", ");
+
+            // For type parameter instantiations, emit inline bodies using $TypeParamInfo.
+            // defining_id/original_id return address (int) so we can use #N_info->a.
+            // with_defining_ids/with_original_ids return an opaque TypeName struct,
+            // so they stay uninterpreted for type params.
+            match &type_inst[0] {
+                Type::TypeParameter(idx) if is_defining_id => {
+                    emitln!(
+                        self.writer,
+                        "function {{:inline}} {}() returns ({})\n{{ #{}_info->a }}",
+                        func_name,
+                        rets,
+                        idx,
+                    );
+                }
+                _ => {
+                    emitln!(self.writer, "function {}() returns ({});", func_name, rets,);
+                }
+            }
+            emitln!(self.writer);
+        }
+    }
+
     // Generate object::borrow_uid function
     fn translate_object_borrow_uid(&self, suffix: &str, obj_name: &str) {
         emitln!(
@@ -463,6 +521,7 @@ impl<'env> BoogieTranslator<'env> {
                             self.emit_uninterpreted_native_pure(fun_env, type_inst);
                         }
                     }
+                    self.emit_type_name_functions(fun_env, &mono_info);
                     continue;
                 }
 

--- a/crates/sui-prover/tests/inputs/type_name/type_name_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/type_name/type_name_pure.ok.move
@@ -1,0 +1,21 @@
+/// Test that type_name functions can be used as pure functions (Boogie functions).
+/// This verifies type_name::get<T>() returns a known constant for concrete types.
+module 0x42::type_name_pure;
+
+use std::type_name;
+#[spec_only]
+use prover::prover::ensures;
+
+public struct MyCoin has drop {}
+
+public fun get_type_name(): type_name::TypeName {
+    type_name::get<MyCoin>()
+}
+
+#[spec(prove)]
+fun get_type_name_spec(): type_name::TypeName {
+    let result = get_type_name();
+    // type_name::get returns a deterministic value for a given type
+    ensures(result == type_name::get<MyCoin>());
+    result
+}

--- a/crates/sui-prover/tests/snapshots/type_name/type_name_pure.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/type_name/type_name_pure.ok.move.snap
@@ -1,0 +1,21 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+Verification successful
+warning: deprecated usage
+   ┌─ tests/inputs/type_name/type_name_pure.ok.move:12:16
+   │
+12 │     type_name::get<MyCoin>()
+   │                ^^^ The function 'std::type_name::get' is deprecated: Renamed to `with_defining_ids` for clarity.
+   │
+   = This warning can be suppressed with '#[allow(deprecated_usage)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning: deprecated usage
+   ┌─ tests/inputs/type_name/type_name_pure.ok.move:19:34
+   │
+19 │     ensures(result == type_name::get<MyCoin>());
+   │                                  ^^^ The function 'std::type_name::get' is deprecated: Renamed to `with_defining_ids` for clarity.
+   │
+   = This warning can be suppressed with '#[allow(deprecated_usage)]' applied to the 'module' or module member ('const', 'fun', or 'struct')


### PR DESCRIPTION
Add std::type_name functions (with_defining_ids, with_original_ids, defining_id, original_id) to native_fn_ids() and emit uninterpreted Boogie function declarations for them. This allows type_name functions to be used in quantifier expressions (forall/exists).

Related https://github.com/asymptotic-code/sui-prover/issues/530