### PR TITLE
fix: skip TraceLocal ops when building Pure style bytecode

### DIFF
--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -1040,15 +1040,25 @@ impl<'env> BoogieTranslator<'env> {
                             .update_abort_action(|_| None),
                     ),
                 },
-                FunctionTranslationStyle::Pure => {
-                    // workaround: for pure functions, we just remove all casts via replacing with assigns (only in non-bitvector mode)
-                    let mut bc = bc.update_abort_action(|_| None);
-                    if self.targets.prover_options().bv_int_encoding {
-                        // only in non-bitvector mode
-                        bc = bc.replace_cast_with_assign();
+                FunctionTranslationStyle::Pure => match bc {
+                    Call(_, _, op, _, _)
+                        if matches!(
+                            op,
+                            Operation::TraceLocal { .. }
+                                | Operation::TraceReturn { .. }
+                                | Operation::TraceMessage { .. }
+                                | Operation::TraceGhost { .. }
+                        ) => {} // Skip trace operations - they have no place in pure function translation
+                    _ => {
+                        // workaround: for pure functions, we just remove all casts via replacing with assigns (only in non-bitvector mode)
+                        let mut bc = bc.update_abort_action(|_| None);
+                        if self.targets.prover_options().bv_int_encoding {
+                            // only in non-bitvector mode
+                            bc = bc.replace_cast_with_assign();
+                        }
+                        builder.emit(bc);
                     }
-                    builder.emit(bc);
-                }
+                },
             }
         }
 

--- a/crates/sui-prover/tests/inputs/pure_functions/issue_544.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/issue_544.move
@@ -1,0 +1,42 @@
+/// Regression test for https://github.com/asymptotic-code/sui-prover/issues/544
+/// Panic: "unexpected 0 destinations for operation TraceLocal(0) in function table_is_good"
+///
+/// Root cause: when a non-pure function is called by a #[ext(pure)] function,
+/// it becomes a "pure callee" and is translated with FunctionTranslationStyle::Pure.
+/// The Pure arm in the bytecode builder did not filter out TraceLocal operations
+/// (which have 0 destinations), so generate_pure_expression panicked when it
+/// encountered them in the Call handler expecting exactly 1 destination.
+module 0x42::issue_544;
+
+use prover::prover::{ensures, forall};
+
+// Pure predicate function called from within the quantifier
+#[ext(pure)]
+fun is_at_least(x: &u64, bound: u64): bool {
+    *x >= bound
+}
+
+// A non-pure function that uses forall! (not marked #[ext(pure)])
+// This becomes a "pure callee" when called from is_valid_bound.
+fun all_values_at_least(bound: u64): bool {
+    forall!<u64>(|x| is_at_least(x, bound))
+}
+
+// A pure function that calls the non-pure function (making it a "pure callee").
+// When this is marked #[ext(pure)], the non-pure callee gets translated with
+// FunctionTranslationStyle::Pure, which previously panicked on TraceLocal ops
+// (with debug_trace=true, which is the default for CLI usage).
+#[ext(pure)]
+fun is_valid_bound(lower: u64, upper: u64): bool {
+    all_values_at_least(lower) && upper >= lower
+}
+
+public fun check_bound(lower: u64, upper: u64): bool {
+    is_valid_bound(lower, upper)
+}
+
+#[spec(prove)]
+fun test_check_bound() {
+    let result = check_bound(0, 100);
+    ensures(result);
+}

--- a/crates/sui-prover/tests/snapshots/pure_functions/issue_544.move.snap
+++ b/crates/sui-prover/tests/snapshots/pure_functions/issue_544.move.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-prover/tests/integration.rs
+expression: output
+---
+Verification successful


### PR DESCRIPTION
Fix panic "unexpected 0 destinations for operation TraceLocal(0)" that occurred when a non-pure function called by a #[ext(pure)] function contained TraceLocal operations in its bytecode.

The FunctionTranslationStyle::Pure arm now skips trace operations (TraceLocal, TraceReturn, TraceMessage, TraceGhost) when building bytecode for pure/pure-callee functions, mirroring what the Asserts/Aborts style already does.

Closes #544

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes handling of debug trace operations during `FunctionTranslationStyle::Pure` translation and adds a regression test; core verification semantics should be unchanged.
> 
> **Overview**
> Fixes a crash during `FunctionTranslationStyle::Pure` translation by **skipping trace-related `Call` operations** (`TraceLocal`, `TraceReturn`, `TraceMessage`, `TraceGhost`) which can have zero destinations and previously triggered a panic.
> 
> Adds a regression Move test (`pure_functions/issue_544.move`) plus snapshot asserting successful verification for the pure-callee scenario that used to fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ceec758f708c23ba872e38f3ef2268ebcd7bdcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->