### PR TITLE
Fixed the progress display while tracing; also display list of timeouts

### DIFF
--- a/crates/move-prover-boogie-backend/src/boogie_backend/boogie_wrapper.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/boogie_wrapper.rs
@@ -806,7 +806,8 @@ impl<'env> BoogieWrapper<'env> {
                             println!("    \u{274c} {}", trimmed);
                         }
                     }
-                } else if trimmed.starts_with("--> split #") { // status line
+                } else if trimmed.starts_with("--> split #") {
+                    // status line
                     if trimmed.ends_with("TimeOut") {
                         if let Some(info) = analysis.assertions.get(&prev_bpl_line) {
                             timeouts.push(info.description.clone())


### PR DESCRIPTION
Some lines were not being erased properly under --trace.  Fixed that.

Also added something to note the timeout failures under --trace and to report them when the proof effort is finished.  This could be better, as it only shows the source line of the failing assertion, not the whole backtrace, but it is better than what we had before.