### PR TITLE
Add Lean 4 showcase proofs for issue 452 constructor lowering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ output/
 .sparse
 
 crates/sui-prover/tests/sources/*
+
+# Local project memory / operator docs
+AGENTS.md
+MEMORY.md
+RUNBOOK.md

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ crates/sui-prover/tests/sources/*
 AGENTS.md
 MEMORY.md
 RUNBOOK.md
+
+# Lean local build artifacts
+lean/.lake/
+lean/lake-manifest.json

--- a/crates/sui-prover/tests/inputs/pure_functions/issue_452.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/issue_452.move
@@ -1,0 +1,25 @@
+/// Repro for https://github.com/asymptotic-code/sui-prover/issues/452
+/// Panic when a pure function uses `exists!` with enum variant construction.
+module 0x42::issue_452;
+
+use prover::prover::ensures;
+
+public enum E has copy, drop {
+    A,
+    B(u8),
+}
+
+#[ext(pure)]
+public fun f2(e: E): bool {
+    e == E::A || prover::prover::exists!(|v| is_b(*v, e))
+}
+
+#[ext(pure)]
+public fun is_b(v: u8, e: E): bool {
+    e == E::B(v)
+}
+
+#[spec(prove)]
+fun test() {
+    ensures(f2(E::B(1)))
+}

--- a/crates/sui-prover/tests/inputs/pure_functions/issue_452_match.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/issue_452_match.move
@@ -1,0 +1,23 @@
+/// Alternate repro from https://github.com/asymptotic-code/sui-prover/issues/452
+/// Matching on an enum inside a pure function reports a misleading loop error.
+module 0x42::issue_452_match;
+
+use prover::prover::ensures;
+
+public enum E has copy, drop {
+    A,
+    B(u8),
+}
+
+#[ext(pure)]
+public fun f(e: E): bool {
+    match (e) {
+        E::A => true,
+        E::B(v) => v > 0,
+    }
+}
+
+#[spec(prove)]
+fun test() {
+    ensures(f(E::B(1)))
+}

--- a/crates/sui-prover/tests/snapshots/pure_functions/issue_452.move.snap
+++ b/crates/sui-prover/tests/snapshots/pure_functions/issue_452.move.snap
@@ -1,0 +1,6 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+Verification failed, panic during verification: "unexpected operation PackVariant(ModuleId(123), DatatypeId(Symbol(1793)), VariantId(Symbol(1797)), []) in function issue_452::f2"

--- a/crates/sui-prover/tests/snapshots/pure_functions/issue_452_match.move.snap
+++ b/crates/sui-prover/tests/snapshots/pure_functions/issue_452_match.move.snap
@@ -1,0 +1,16 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+exiting with bytecode transformation errors
+error: Pure functions with loops are not supported
+   ┌─ tests/inputs\pure_functions\issue_452_match.move:13:1
+   │  
+13 │ ╭ public fun f(e: E): bool {
+14 │ │     match (e) {
+15 │ │         E::A => true,
+16 │ │         E::B(v) => v > 0,
+17 │ │     }
+18 │ │ }
+   │ ╰─^

--- a/lean/Issue452.lean
+++ b/lean/Issue452.lean
@@ -1,0 +1,4 @@
+import Issue452.Core
+import Issue452.MatchBoundary
+import Issue452.PureLowering
+import Issue452.QuantifierView

--- a/lean/Issue452/Core.lean
+++ b/lean/Issue452/Core.lean
@@ -1,0 +1,98 @@
+namespace Issue452
+
+/-!
+# Core
+
+This file contains the smallest semantic core needed to talk about the
+`issue_452` fix:
+
+- a tiny enum with two constructors
+- the witness predicate corresponding to the repro helper
+- the top-level pure predicate
+- basic completeness and equivalence lemmas
+-/
+
+inductive E where
+  | A
+  | B (v : Nat)
+deriving DecidableEq, Repr
+
+/-! ## Source-level predicates -/
+
+def isB (v : Nat) : E → Prop
+  | .B w => w = v
+  | .A => False
+
+def f2 (e : E) : Prop :=
+  e = .A ∨ ∃ v, isB v e
+
+def lowerPackVariantA : E :=
+  .A
+
+def lowerPackVariantB (v : Nat) : E :=
+  .B v
+
+theorem lowerPackVariantA_sound : lowerPackVariantA = E.A := rfl
+
+theorem lowerPackVariantB_sound (v : Nat) : lowerPackVariantB v = E.B v := rfl
+
+theorem isB_iff_eq_B (v : Nat) (e : E) : isB v e ↔ e = .B v := by
+  cases e with
+  | A =>
+      simp [isB]
+  | B w =>
+      simp [isB]
+
+theorem f2_of_A : f2 .A :=
+  Or.inl rfl
+
+theorem f2_of_B (v : Nat) : f2 (.B v) :=
+  Or.inr ⟨v, rfl⟩
+
+/-! ## Completeness and lowered-view lemmas -/
+
+theorem constructor_cases_complete (e : E) : e = .A ∨ ∃ v, e = .B v := by
+  cases e with
+  | A =>
+      exact Or.inl rfl
+  | B v =>
+      exact Or.inr ⟨v, rfl⟩
+
+theorem f2_total (e : E) : f2 e := by
+  rcases constructor_cases_complete e with hA | ⟨v, hB⟩
+  · simpa [hA] using f2_of_A
+  · simpa [hB] using f2_of_B v
+
+def loweredF2 (e : E) : Prop :=
+  e = lowerPackVariantA ∨ ∃ v, e = lowerPackVariantB v
+
+theorem loweredF2_iff_f2 (e : E) : loweredF2 e ↔ f2 e := by
+  constructor
+  · intro h
+    rcases h with hA | ⟨v, hB⟩
+    · cases hA
+      simpa [lowerPackVariantA] using f2_of_A
+    · cases hB
+      simpa [lowerPackVariantB] using f2_of_B v
+  · intro h
+    rcases constructor_cases_complete e with hA | ⟨v, hB⟩
+    · exact Or.inl hA
+    · exact Or.inr ⟨v, hB⟩
+
+theorem f2_of_lowered_pack_variant (v : Nat) : f2 (lowerPackVariantB v) := by
+  simpa [lowerPackVariantB] using f2_of_B v
+
+theorem exists_witness_roundtrip (v : Nat) : ∃ witness, isB witness (.B v) := by
+  exact ⟨v, rfl⟩
+
+theorem lowered_exists_witness_roundtrip (v : Nat) :
+    ∃ witness, isB witness (lowerPackVariantB v) := by
+  simpa [lowerPackVariantB] using exists_witness_roundtrip v
+
+theorem lowerPackVariant_preserves_f2 (v : Nat) :
+    loweredF2 (lowerPackVariantB v) ∧ f2 (lowerPackVariantB v) := by
+  constructor
+  · exact Or.inr ⟨v, rfl⟩
+  · exact f2_of_lowered_pack_variant v
+
+end Issue452

--- a/lean/Issue452/MatchBoundary.lean
+++ b/lean/Issue452/MatchBoundary.lean
@@ -1,0 +1,65 @@
+import Issue452.Core
+import Issue452.PureLowering
+
+namespace Issue452
+
+/-!
+# MatchBoundary
+
+This module documents the current proof boundary.
+
+The Rust fix for `issue_452` establishes correct lowering for pure enum
+constructor expressions, but it does **not** implement full pure lowering
+for enum `match` / `VariantSwitch`. The main prover therefore reports the
+constructive case as supported and the match case as unsupported.
+-/
+
+inductive ExtendedExpr where
+  | ctorA
+  | ctorB (v : Nat)
+  | matchOn (e : E)
+deriving DecidableEq, Repr
+
+def supportedForLowering : ExtendedExpr → Prop
+  | .ctorA => True
+  | .ctorB _ => True
+  | .matchOn _ => False
+
+def lowerExtended : ExtendedExpr → Option E
+  | .ctorA => some lowerPackVariantA
+  | .ctorB v => some (lowerPackVariantB v)
+  | .matchOn _ => none
+
+theorem constructors_are_supported (expr : SourceExpr) :
+    supportedForLowering
+      (match expr with
+      | .ctorA => .ctorA
+      | .ctorB v => .ctorB v) := by
+  cases expr <;> simp [supportedForLowering]
+
+theorem enum_match_is_not_supported (e : E) :
+    ¬ supportedForLowering (.matchOn e) := by
+  simp [supportedForLowering]
+
+theorem lowering_rejects_match (e : E) : lowerExtended (.matchOn e) = none := by
+  simp [lowerExtended]
+
+theorem lowering_accepts_supported_subset (expr : SourceExpr) :
+    ∃ lowered, lowerExtended
+      (match expr with
+      | .ctorA => .ctorA
+      | .ctorB v => .ctorB v) = some lowered := by
+  cases expr with
+  | ctorA =>
+      exact ⟨lowerPackVariantA, by simp [lowerExtended]⟩
+  | ctorB v =>
+      exact ⟨lowerPackVariantB v, by simp [lowerExtended]⟩
+
+theorem supported_subset_matches_core_lowering (expr : SourceExpr) :
+    lowerExtended
+      (match expr with
+      | .ctorA => .ctorA
+      | .ctorB v => .ctorB v) = some (lowerSource expr) := by
+  cases expr <;> simp [lowerExtended, lowerSource]
+
+end Issue452

--- a/lean/Issue452/PureLowering.lean
+++ b/lean/Issue452/PureLowering.lean
@@ -1,0 +1,77 @@
+import Issue452.Core
+
+namespace Issue452
+
+/-!
+# PureLowering
+
+This file isolates the constructor-only lowering story:
+
+- define a tiny source-expression language with constructor forms only
+- evaluate the source form
+- lower it into the target enum directly
+- prove that the lowering preserves both the witness predicate and the top-level property
+-/
+
+inductive SourceExpr where
+  | ctorA
+  | ctorB (v : Nat)
+deriving DecidableEq, Repr
+
+/-! ## Constructor-only source language -/
+
+def evalSource : SourceExpr → E
+  | .ctorA => .A
+  | .ctorB v => .B v
+
+def lowerSource : SourceExpr → E
+  | .ctorA => lowerPackVariantA
+  | .ctorB v => lowerPackVariantB v
+
+theorem lowerSource_sound (expr : SourceExpr) : lowerSource expr = evalSource expr := by
+  cases expr with
+  | ctorA =>
+      simp [lowerSource, evalSource, lowerPackVariantA]
+  | ctorB v =>
+      simp [lowerSource, evalSource, lowerPackVariantB]
+
+def evalIsBSource (target : Nat) : SourceExpr → Prop
+  | .ctorA => False
+  | .ctorB v => v = target
+
+def evalIsBLowered (target : Nat) (expr : SourceExpr) : Prop :=
+  isB target (lowerSource expr)
+
+theorem evalIsB_preserved (target : Nat) (expr : SourceExpr) :
+    evalIsBLowered target expr ↔ evalIsBSource target expr := by
+  cases expr with
+  | ctorA =>
+      simp [evalIsBLowered, evalIsBSource, lowerSource, lowerPackVariantA, isB]
+  | ctorB v =>
+      simp [evalIsBLowered, evalIsBSource, lowerSource, lowerPackVariantB, isB]
+
+def evalF2Source : SourceExpr → Prop :=
+  f2 ∘ evalSource
+
+def evalF2Lowered : SourceExpr → Prop :=
+  f2 ∘ lowerSource
+
+theorem evalF2_preserved (expr : SourceExpr) :
+    evalF2Lowered expr ↔ evalF2Source expr := by
+  simp [evalF2Lowered, evalF2Source, lowerSource_sound]
+
+theorem ctorB_has_witness_after_lowering (v : Nat) :
+    ∃ witness, isB witness (lowerSource (.ctorB v)) := by
+  refine ⟨v, ?_⟩
+  simp [lowerSource, lowerPackVariantB, isB]
+
+theorem lowering_preserves_totality (expr : SourceExpr) : evalF2Lowered expr := by
+  have h : evalF2Source expr := by
+    cases expr with
+    | ctorA =>
+        simpa [evalF2Source, evalSource] using f2_of_A
+    | ctorB v =>
+        simpa [evalF2Source, evalSource] using f2_of_B v
+  exact (evalF2_preserved expr).2 h
+
+end Issue452

--- a/lean/Issue452/QuantifierView.lean
+++ b/lean/Issue452/QuantifierView.lean
@@ -1,0 +1,71 @@
+import Issue452.Core
+import Issue452.PureLowering
+
+namespace Issue452
+
+/-!
+`exists!`-style view specialized to the tiny `issue_452` model.
+We separate the quantifier-facing statement from the lower-level
+constructor-preservation statements so the showcase reads more like
+an appendix: first define the witness shape, then prove it is preserved.
+-/
+
+/-! ## Witness-oriented quantifier view -/
+def hasIsBWitness (e : E) : Prop :=
+  ∃ witness, isB witness e
+
+def hasIsBWitnessSource : SourceExpr → Prop :=
+  hasIsBWitness ∘ evalSource
+
+def hasIsBWitnessLowered : SourceExpr → Prop :=
+  hasIsBWitness ∘ lowerSource
+
+theorem witness_for_ctorB_source (v : Nat) : hasIsBWitnessSource (.ctorB v) := by
+  refine ⟨v, ?_⟩
+  simp [evalSource, isB]
+
+theorem no_witness_for_ctorA_source : ¬ hasIsBWitnessSource .ctorA := by
+  intro h
+  rcases h with ⟨witness, hwitness⟩
+  simp [evalSource, isB] at hwitness
+
+theorem witness_for_ctorB_lowered (v : Nat) : hasIsBWitnessLowered (.ctorB v) := by
+  refine ⟨v, ?_⟩
+  simp [lowerSource, lowerPackVariantB, isB]
+
+theorem no_witness_for_ctorA_lowered : ¬ hasIsBWitnessLowered .ctorA := by
+  intro h
+  rcases h with ⟨witness, hwitness⟩
+  simp [lowerSource, lowerPackVariantA, isB] at hwitness
+
+theorem quantifier_view_preserved (expr : SourceExpr) :
+    hasIsBWitnessLowered expr ↔ hasIsBWitnessSource expr := by
+  cases expr with
+  | ctorA =>
+      simp [hasIsBWitnessLowered, hasIsBWitnessSource, hasIsBWitness, lowerSource, evalSource,
+        lowerPackVariantA, isB]
+  | ctorB v =>
+      simp [hasIsBWitnessLowered, hasIsBWitnessSource, hasIsBWitness, lowerSource, evalSource,
+        lowerPackVariantB, isB]
+
+theorem quantified_branch_matches_f2 (expr : SourceExpr) :
+    evalF2Lowered expr ↔ (evalSource expr = .A ∨ hasIsBWitnessLowered expr) := by
+  cases expr with
+  | ctorA =>
+      simp [evalF2Lowered, f2, lowerSource, evalSource, hasIsBWitnessLowered, hasIsBWitness,
+        lowerPackVariantA, isB]
+  | ctorB v =>
+      simp [evalF2Lowered, f2, lowerSource, evalSource, hasIsBWitnessLowered, hasIsBWitness,
+        lowerPackVariantB, isB]
+
+theorem lowered_quantifier_is_constructive (expr : SourceExpr) :
+    hasIsBWitnessLowered expr → ∃ witness, lowerSource expr = .B witness := by
+  intro h
+  cases expr with
+  | ctorA =>
+      exfalso
+      exact no_witness_for_ctorA_lowered h
+  | ctorB v =>
+      exact ⟨v, by simp [lowerSource, lowerPackVariantB]⟩
+
+end Issue452

--- a/lean/ProofToCode.md
+++ b/lean/ProofToCode.md
@@ -1,0 +1,56 @@
+# Proof-to-Code Mapping
+
+This note connects the small Lean 4 showcase to the concrete Rust fix for `issue_452`.
+
+## Goal
+
+Show that the Lean proofs are not random toy lemmas, but a compact semantic mirror of the real fix:
+
+- Rust fixes pure lowering of enum variant constructors
+- Lean proves that constructor-based lowering preserves the intended witness-oriented meaning
+
+## Rust → Lean correspondence
+
+| Rust / prover concept | Lean counterpart | Why it matters |
+| --- | --- | --- |
+| `Operation::PackVariant` in pure lowering | `SourceExpr.ctorA` / `SourceExpr.ctorB` | Represents source-level enum construction |
+| enum value `E::A` / `E::B(v)` | `Issue452.E.A` / `Issue452.E.B v` | Shared semantic object |
+| pure helper `is_b(v, e)` | `isB v e` | The witness predicate from the repro |
+| pure helper `f2(e)` | `f2 e` | The top-level property used in the regression |
+| lowering to a constructor expression | `lowerSource` | The semantic act being justified |
+| "lowered program means the same thing" | `lowerSource_sound` / `evalF2_preserved` | Core soundness story |
+| existential witness in `exists!` branch | `hasIsBWitness` | Captures the quantifier-facing view |
+| constructor lowering still provides a witness | `quantifier_view_preserved` | Explains why the repro should stop panicking |
+| current unsupported pure enum `match` lowering | `MatchBoundary` module | Makes the proof boundary explicit |
+
+## File mapping
+
+- `crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs`
+  - Rust implementation of the `PackVariant` pure lowering fix
+- `lean/Issue452/Core.lean`
+  - Minimal semantic model of the enum and the `f2` property
+- `lean/Issue452/PureLowering.lean`
+  - Proof that constructor lowering preserves the source meaning
+- `lean/Issue452/QuantifierView.lean`
+  - Proof that the existential witness view is preserved
+- `lean/Issue452/MatchBoundary.lean`
+  - Proof-oriented statement of the current unsupported boundary
+
+## Reading order
+
+1. `Core.lean`
+2. `PureLowering.lean`
+3. `QuantifierView.lean`
+4. `MatchBoundary.lean`
+
+## What this does **not** claim
+
+- It does not replace the Boogie/Z3 prover.
+- It does not prove the whole Sui Prover pipeline correct.
+- It does not prove pure enum `match` lowering, because the current Rust code still reports that as unsupported.
+
+## What it *does* claim
+
+- The central `issue_452` fix has a clean semantic story.
+- Constructor-based lowering is the right shape for the supported subset.
+- The witness-producing branch used by the repro remains meaningful after lowering.

--- a/lean/README.md
+++ b/lean/README.md
@@ -1,0 +1,52 @@
+# Lean 4 Showcase
+
+This directory is a small, separate Lean 4 proof showcase for `issue_452`.
+
+It does **not** replace the main Boogie/Z3 verification pipeline. Instead, it demonstrates a
+machine-checked proof of the core enum-construction idea behind the fix:
+
+- model a tiny enum `E = A | B Nat`
+- model the pure helper predicate shape used in the repro
+- prove that lowering a packed enum variant into a direct constructor expression is sound
+- prove that `f2 (E.B v)` holds with an explicit existential witness
+- prove constructor-case completeness for the tiny enum model
+- prove an equivalence between the lowered representation and the source-level predicate
+
+## Files
+
+- `lean/Issue452.lean` — root export module
+- `lean/Issue452/Core.lean` — tiny enum model and base theorems
+- `lean/Issue452/PureLowering.lean` — lowering-preservation proofs
+- `lean/Issue452/QuantifierView.lean` — `exists!`-style witness proofs
+- `lean/Issue452/MatchBoundary.lean` — explicit unsupported-boundary statement for pure enum `match`
+- `lean/lakefile.toml` — minimal Lake project config
+- `lean/lean-toolchain` — pinned Lean 4 toolchain
+- `lean/ProofToCode.md` — Rust ↔ Lean concept mapping
+
+## Suggested local commands
+
+```powershell
+cd lean
+lake build
+```
+
+If `lake` is not on the current shell `PATH`, open a new terminal after the user-level environment
+changes, or invoke it via `C:\Users\peter\.elan\bin\lake.exe`.
+
+## Main theorems
+
+- `isB_iff_eq_B`
+- `constructor_cases_complete`
+- `f2_total`
+- `loweredF2_iff_f2`
+- `lowerPackVariant_preserves_f2`
+- `lowerSource_sound`
+- `evalIsB_preserved`
+- `evalF2_preserved`
+- `lowering_preserves_totality`
+- `quantifier_view_preserved`
+- `quantified_branch_matches_f2`
+- `lowered_quantifier_is_constructive`
+- `enum_match_is_not_supported`
+- `lowering_rejects_match`
+- `supported_subset_matches_core_lowering`

--- a/lean/lakefile.toml
+++ b/lean/lakefile.toml
@@ -1,0 +1,6 @@
+name = "issue452"
+version = "0.1.0"
+defaultTargets = ["Issue452"]
+
+[[lean_lib]]
+name = "Issue452"

--- a/lean/lean-toolchain
+++ b/lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.28.0


### PR DESCRIPTION
## Summary
- add a small standalone Lean 4 showcase project under `lean/`
- model the core enum and witness semantics behind `issue_452`
- prove constructor-only lowering preservation and witness preservation
- document the current proof boundary for unsupported pure enum `match` lowering
- add a Rust-to-Lean proof mapping note

## Scope
This PR is intentionally a showcase and documentation layer. It does not replace the main Boogie + Z3 verification pipeline and it does not claim full correctness of the entire prover.

## Included modules
- `Core` for the tiny enum model and base theorems
- `PureLowering` for constructor-lowering preservation
- `QuantifierView` for the existential witness / `exists!`-style view
- `MatchBoundary` for the currently unsupported pure enum `match` boundary
- `ProofToCode.md` for Rust-to-Lean concept mapping

## Validation
- `lake build`

## Notes for reviewers
- The proof scope is deliberately limited to the constructor-only subset fixed by `issue_452`.
- The `MatchBoundary` module explicitly states that pure enum `match` lowering remains unsupported.
- This PR is designed to be reviewed independently from the Rust bugfix PR for easier focus.
- This PR has no runtime impact on the existing prover pipeline.
