### PR TITLE
fix: handle single-field Unpack in generate_pure_expression

### DIFF
--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -3097,13 +3097,29 @@ impl<'env> FunctionTranslator<'env> {
                     if matches!(op, Destroy) {
                         continue;
                     }
-                    // Multi-destination operations: handle the patterns that
-                    // can legitimately appear inside a pure body.
+                    // Struct destructuring: `let S { a, b } = s` (or the
+                    // positional form `let S(x) = s`). Bind each destination
+                    // to the corresponding field selector on the source. This
+                    // covers both single-field (dests.len() == 1) and
+                    // multi-field structs.
+                    if let Operation::Unpack(mid, sid, inst) = op {
+                        let inst = &self.inst_slice(inst);
+                        let struct_env = fun_target.global_env().get_module(*mid).into_struct(*sid);
+                        let src_str = fmt_temp(srcs[0]);
+                        for (i, ref field_env) in struct_env.get_fields().enumerate() {
+                            bindings.push((
+                                format!("$t{}", dests[i]),
+                                format!("{}->{}", src_str, boogie_field_sel(field_env, inst)),
+                            ));
+                        }
+                        continue;
+                    }
+                    // Tuple-returning function call: a pure body that
+                    // destructures a multi-return callee. Bind the call
+                    // result to a synthetic tuple temp, then project each
+                    // destination via the boogie datatype selectors
+                    // (`->$ret0`, `->$ret1`, ...).
                     if dests.len() > 1 {
-                        // Tuple-returning function call. Bind the call
-                        // result to a synthetic tuple temp, then project
-                        // each destination via the boogie datatype
-                        // selectors (`->$ret0`, `->$ret1`, ...).
                         if let Function(mid, fid, inst) = op {
                             let callee_env = self.parent.env.get_function(mid.qualified(*fid));
                             let native_fn =
@@ -3139,22 +3155,6 @@ impl<'env> FunctionTranslator<'env> {
                                 bindings.push((
                                     format!("$t{}", dest),
                                     format!("{}->$ret{}", tuple_name, i),
-                                ));
-                            }
-                            continue;
-                        }
-                        // Struct destructuring: `let S { a, b } = s`.
-                        // Bind each destination to the corresponding
-                        // field selector on the source.
-                        if let Operation::Unpack(mid, sid, inst) = op {
-                            let inst = &self.inst_slice(inst);
-                            let struct_env =
-                                fun_target.global_env().get_module(*mid).into_struct(*sid);
-                            let src_str = fmt_temp(srcs[0]);
-                            for (i, ref field_env) in struct_env.get_fields().enumerate() {
-                                bindings.push((
-                                    format!("$t{}", dests[i]),
-                                    format!("{}->{}", src_str, boogie_field_sel(field_env, inst)),
                                 ));
                             }
                             continue;

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_single_field_unpack.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_single_field_unpack.ok.move
@@ -1,0 +1,23 @@
+module 0x42::pure_single_field_unpack;
+
+#[spec_only]
+use prover::prover::{requires, val};
+
+public struct S(u8) has copy, drop;
+
+#[ext(pure)]
+public fun unwrap(s: S): u8 {
+    let S(x) = s;
+    x
+}
+
+public fun f(s: S): u8 {
+    s.unwrap() + 1
+}
+
+#[spec(prove)]
+public fun f_spec(s: S): u8 {
+    let s0 = val(&s);
+    requires(s0.unwrap() < 255);
+    f(s)
+}

--- a/crates/sui-prover/tests/snapshots/pure_functions/pure_single_field_unpack.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/pure_functions/pure_single_field_unpack.ok.move.snap
@@ -1,0 +1,6 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+Verification successful


### PR DESCRIPTION
Pull `Unpack` handling out of the multi-dest branch so it runs for any `dests.len()`. A single-field positional struct like `struct S(u8)` in a pure helper (`let S(x) = s`) produces a one-dest `Unpack`, which was falling through to the single-dest op chain and hitting the "unexpected operation" panic.

fixes #574.