### PR TITLE
fix: use the quantified parameter's type when emitting forall/exists …

### DIFF
--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -3464,7 +3464,7 @@ impl<'env> FunctionTranslator<'env> {
 
         match qt {
             QuantifierType::Forall => {
-                let loc_type = fun_env.get_parameter_types()[0]
+                let loc_type = fun_env.get_parameter_types()[li]
                     .skip_reference()
                     .instantiate(inst);
                 let b_type = boogie_type(env, &loc_type);
@@ -3478,7 +3478,7 @@ impl<'env> FunctionTranslator<'env> {
                 )
             }
             QuantifierType::Exists => {
-                let loc_type = fun_env.get_parameter_types()[0]
+                let loc_type = fun_env.get_parameter_types()[li]
                     .skip_reference()
                     .instantiate(inst);
                 let b_type = boogie_type(env, &loc_type);

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_forall_trailing_binder.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_forall_trailing_binder.ok.move
@@ -1,0 +1,29 @@
+/// Test that `forall!` inside a pure helper works when the quantified
+/// parameter of the inner predicate is NOT the first parameter. Previously
+/// the Boogie backend declared the bound variable with the type of
+/// `get_parameter_types()[0]` instead of `[li]`, so the generated
+/// `(forall x: Vec int :: ... equal_in_range(u, v, i, j, x))` mismatched
+/// the predicate's trailing `int` parameter and Boogie rejected it.
+module 0x42::pure_forall_trailing_binder;
+
+#[spec_only]
+use prover::prover::{ensures, forall};
+
+#[ext(pure)]
+fun equal_in_range(u: &vector<u64>, v: &vector<u64>, i: u64, j: u64, k: u64): bool {
+    k < i || k >= j || k >= u.length() || k >= v.length() || u[k] == v[k]
+}
+
+#[ext(pure)]
+fun equal_range(u: &vector<u64>, v: &vector<u64>, i: u64, j: u64): bool {
+    forall!(|k| equal_in_range(u, v, i, j, *k))
+}
+
+#[spec(prove)]
+fun verify_equal_range(): bool {
+    let u = vector[1u64, 2u64, 3u64];
+    let v = vector[1u64, 2u64, 3u64];
+    let result = equal_range(&u, &v, 0, 3);
+    ensures(result);
+    result
+}

--- a/crates/sui-prover/tests/snapshots/pure_functions/pure_forall_trailing_binder.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/pure_functions/pure_forall_trailing_binder.ok.move.snap
@@ -1,0 +1,6 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 297
+expression: output
+---
+Verification successful


### PR DESCRIPTION
…bindings

In `generate_pure_quantifier_expr`, the Forall/Exists arms declared the bound variable's type from `fun_env.get_parameter_types()[0]`, so any predicate whose quantified parameter wasn't the first one produced a boogie binder with the wrong type. Use `[li]` — the index of the quantified parameter — to match what `cr_args` substitutes.

Symptom: `forall!(|k| p(u, v, i, j, *k))` (k at position 4) emitted
`(forall x: Vec int :: ... p(u, v, i, j, x))` and boogie rejected it
with "invalid type for argument 4: Vec int (expected: int)".

fixes #575.