### PR TITLE
feat(targets): accept #[ext(spec_only)] alongside the bare verificati…

### DIFF
--- a/crates/move-stackless-bytecode/src/package_targets.rs
+++ b/crates/move-stackless-bytecode/src/package_targets.rs
@@ -4,7 +4,8 @@ use move_binary_format::file_format::FunctionHandleIndex;
 use move_compiler::{
     expansion::ast::{ModuleAccess, ModuleAccess_, ModuleIdent_},
     shared::known_attributes::{
-        AttributeKind_, ExternalAttribute, KnownAttribute, VerificationAttribute,
+        AttributeKind_, ExternalAttribute, ExternalAttributeEntry_, KnownAttribute,
+        VerificationAttribute,
     },
 };
 use move_ir_types::location::Spanned;
@@ -295,6 +296,29 @@ impl PackageTargets {
     }
 
     fn check_spec_only_scope(&mut self, func_env: &FunctionEnv) {
+        // Try the bare verification form first; fall back to the upstream-compiler-compatible
+        // `#[ext(spec_only)]` wrapper. Only the parameterless ext form is recognized — for
+        // parameterized usage (`spec_only(loop_inv(...), axiom, extra_bpl=...)`) keep the bare
+        // syntax. This lets projects using the official Mysten Labs sui CLI (which warns on
+        // unknown bare attributes via W02018) annotate accessor-style spec_only functions in
+        // the wrapped form without losing prover recognition.
+        let owned;
+        let spec_only_ref = if let Some(va) = func_env
+            .get_toplevel_attributes()
+            .get_(&AttributeKind_::SpecOnly)
+            .map(|attr| &attr.value)
+        {
+            Some(va)
+        } else if Self::has_bare_ext_attribute(
+            func_env.get_toplevel_attributes(),
+            "spec_only",
+        ) {
+            owned = KnownAttribute::Verification(Self::default_spec_only());
+            Some(&owned)
+        } else {
+            None
+        };
+
         if let Some(KnownAttribute::Verification(VerificationAttribute::SpecOnly {
             inv_target,
             loop_inv,
@@ -302,10 +326,7 @@ impl PackageTargets {
             explicit_specs: _,
             axiom,
             extra_bpl,
-        })) = func_env
-            .get_toplevel_attributes()
-            .get_(&AttributeKind_::SpecOnly)
-            .map(|attr| &attr.value)
+        })) = spec_only_ref
         {
             if func_env.get_name_str().contains("type_inv") {
                 return;
@@ -862,6 +883,42 @@ impl PackageTargets {
         Some(result)
     }
 
+    /// Detects a parameterless `#[ext(<name>)]` attribute (e.g. `#[ext(spec_only)]`).
+    /// Parameterized forms like `#[ext(spec_only(loop_inv(...)))]` are intentionally
+    /// not matched here — those keep the bare verification syntax for now.
+    fn has_bare_ext_attribute(
+        attrs: &move_compiler::expansion::ast::Attributes,
+        name: &str,
+    ) -> bool {
+        if let Some(KnownAttribute::External(ExternalAttribute { attrs: ext_attrs })) = attrs
+            .get_(&AttributeKind_::External)
+            .map(|attr| &attr.value)
+        {
+            ext_attrs.iter().any(|(_, _, entry)| {
+                matches!(
+                    &entry.value,
+                    ExternalAttributeEntry_::Name(n) if n.value.as_str() == name
+                )
+            })
+        } else {
+            false
+        }
+    }
+
+    /// All-defaults `SpecOnly` payload used when discovering a parameterless
+    /// `#[ext(spec_only)]`. Matches what the compiler fork's parser would yield
+    /// for a bare `#[spec_only]` with no inner attributes.
+    fn default_spec_only() -> VerificationAttribute {
+        VerificationAttribute::SpecOnly {
+            axiom: false,
+            extra_bpl: Vec::new(),
+            inv_target: None,
+            loop_inv: None,
+            explicit_specs: Vec::new(),
+            explicit_spec_modules: Vec::new(),
+        }
+    }
+
     fn validate_and_read_extra_bpl(
         env: &GlobalEnv,
         loc: &move_model::model::Loc,
@@ -926,6 +983,25 @@ impl PackageTargets {
     }
 
     fn handle_module_explicit_spec_attributes(&mut self, module_env: &ModuleEnv) {
+        // Mirror the function-level handler: accept bare verification form or
+        // a parameterless `#[ext(spec_only)]` wrapper. See check_spec_only_scope.
+        let owned;
+        let spec_only_ref = if let Some(va) = module_env
+            .get_toplevel_attributes()
+            .get_(&AttributeKind_::SpecOnly)
+            .map(|attr| &attr.value)
+        {
+            Some(va)
+        } else if Self::has_bare_ext_attribute(
+            module_env.get_toplevel_attributes(),
+            "spec_only",
+        ) {
+            owned = KnownAttribute::Verification(Self::default_spec_only());
+            Some(&owned)
+        } else {
+            None
+        };
+
         if let Some(KnownAttribute::Verification(VerificationAttribute::SpecOnly {
             inv_target: _,
             loop_inv: _,
@@ -933,10 +1009,7 @@ impl PackageTargets {
             explicit_spec_modules,
             explicit_specs,
             extra_bpl,
-        })) = module_env
-            .get_toplevel_attributes()
-            .get_(&AttributeKind_::SpecOnly)
-            .map(|attr| &attr.value)
+        })) = spec_only_ref
         {
             if let Some(attrs) = Self::handle_explicit_spec_attributes(
                 module_env,

--- a/crates/sui-prover/tests/inputs/ext_spec_only.ok.move
+++ b/crates/sui-prover/tests/inputs/ext_spec_only.ok.move
@@ -1,0 +1,32 @@
+// Demonstrates that the upstream-compiler-compatible `#[ext(spec_only)]`
+// wrapper is accepted equivalently to the bare `#[spec_only]` attribute.
+//
+// Background: the official Mysten Labs sui CLI's move-compiler does not
+// register `spec_only` as a known attribute and emits warning[W02018]
+// ("Unknown attribute 'spec_only'. Custom attributes must be wrapped in
+// 'ext', e.g. '#[ext(spec_only)]'"). The prover's verification-attribute
+// matcher already accepts the bare form (asymptotic-code/sui fork registers
+// `VerificationAttribute::SpecOnly`); this test exercises the parallel
+// `#[ext(spec_only)]` path through `package_targets::has_bare_ext_attribute`
+// + `default_spec_only`.
+//
+// Parameterized forms (`#[ext(spec_only(loop_inv(...), axiom))]`) are
+// intentionally NOT yet supported — those keep the bare syntax for now.
+
+#[allow(unused_function)]
+module 0x42::ext_spec_only_test;
+
+#[ext(spec_only)]
+use prover::prover::{requires, ensures};
+
+fun double(x: u8): u16 {
+    (x as u16) * 2
+}
+
+#[spec(prove)]
+fun double_spec(x: u8): u16 {
+    requires(x <= 50);
+    let r = double(x);
+    ensures(r <= 100);
+    r
+}


### PR DESCRIPTION
…on form

The official Mysten Labs sui CLI's move-compiler does not register spec_only as a known attribute and emits W02018 ("unknown attribute 'spec_only'. Custom attributes must be wrapped in 'ext', e.g. '#[ext(spec_only)]'") on every annotated declaration. Today the prover only matches the bare verification form (KnownAttribute::Verification(VerificationAttribute::SpecOnly{..})), so projects sharing source between sui move build and sui-prover have no way to clear the warning except --silence-warnings.

This adds a fallback in check_spec_only_scope (:298) and handle_module_explicit_spec_attributes (:928) that recognizes a parameterless #[ext(spec_only)] and synthesizes a default VerificationAttribute::SpecOnly to dispatch through the existing body. Parameterized forms (e.g. spec_only(loop_inv(...), axiom)) keep the bare syntax for now.

- crates/move-stackless-bytecode/src/package_targets.rs:
  + has_bare_ext_attribute + default_spec_only helpers
  + both spec_only discovery sites prefer the bare verification form, fall back to the ext-wrapped form
- crates/sui-prover/tests/inputs/ext_spec_only.ok.move: new test showing the wrapped form is accepted equivalently. Snapshot will be generated by cargo insta on first CI run.