### PR TITLE
Expose hooks for different backends

### DIFF
--- a/crates/move-stackless-bytecode/src/package_targets.rs
+++ b/crates/move-stackless-bytecode/src/package_targets.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 /// Valid values for the `run_on` attribute in `#[spec(prove, run_on="...")]`.
-pub const VALID_RUN_ON_VALUES: &[&str] = &["local", "cloud"];
+pub const VALID_RUN_ON_VALUES: &[&str] = &["local", "cloud", "boogie"];
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ModuleExternalSpecAttribute {
@@ -1077,6 +1077,17 @@ impl PackageTargets {
 
     pub fn spec_run_on(&self) -> &BTreeMap<QualifiedId<FunId>, String> {
         &self.spec_run_on
+    }
+
+    /// Specs marked `#[spec(prove, run_on="boogie")]`. The Lean backend
+    /// emits these obligations as trusted axioms (the hybrid Boogie+Lean
+    /// flow proves them on the Boogie side).
+    pub fn boogie_proven_specs(&self) -> BTreeSet<QualifiedId<FunId>> {
+        self.spec_run_on
+            .iter()
+            .filter(|(_, value)| value.as_str() == "boogie")
+            .map(|(qid, _)| *qid)
+            .collect()
     }
 
     pub fn loop_invariant_candidates(

--- a/crates/move-stackless-bytecode/src/verification_analysis.rs
+++ b/crates/move-stackless-bytecode/src/verification_analysis.rs
@@ -575,7 +575,7 @@ impl VerificationAnalysisProcessor {
 
     /// Marks all callees of this function to be inlined. Forms a mutual recursion with the
     /// `mark_inlined` function above.
-    fn mark_callees_inlined(fun_env: &FunctionEnv, targets: &mut FunctionTargetsHolder) {
+    pub fn mark_callees_inlined(fun_env: &FunctionEnv, targets: &mut FunctionTargetsHolder) {
         let env = fun_env.module_env.env;
 
         let mut callees = targets


### PR DESCRIPTION
Two small surface changes the Lean backend needs, both no-ops for the Boogie flow.