### PR TITLE
borrow_analysis: compact saved per-offset borrow info

### DIFF
--- a/crates/move-stackless-bytecode/src/borrow_analysis.rs
+++ b/crates/move-stackless-bytecode/src/borrow_analysis.rs
@@ -370,9 +370,24 @@ impl BorrowInfo {
 }
 
 #[derive(Clone, Default)]
-pub struct BorrowInfoAtCodeOffset {
+struct FullBorrowInfoAtCodeOffset {
     pub before: BorrowInfo,
     pub after: BorrowInfo,
+}
+
+#[derive(Clone, Default)]
+pub struct BorrowInfoAtCodeOffset {
+    pub live_nodes_after: SetDomain<BorrowNode>,
+    pub dying_nodes: Vec<(BorrowNode, Vec<Vec<WriteBackAction>>)>,
+}
+
+impl FullBorrowInfoAtCodeOffset {
+    fn saved(&self) -> BorrowInfoAtCodeOffset {
+        BorrowInfoAtCodeOffset {
+            live_nodes_after: self.after.live_nodes.clone(),
+            dying_nodes: self.before.dying_nodes(&self.after),
+        }
+    }
 }
 
 /// Borrow annotation computed by the borrow analysis processor.
@@ -386,22 +401,48 @@ impl BorrowAnnotation {
     pub fn get_summary(&self) -> &BorrowInfo {
         &self.summary
     }
+
     pub fn get_borrow_info_at(&self, code_offset: CodeOffset) -> Option<&BorrowInfoAtCodeOffset> {
         self.code_map.get(&code_offset)
     }
 
-    fn join(&mut self, other: &Self) -> JoinResult {
-        let mut result = self.summary.join(&other.summary);
-        for (offset, info) in self.code_map.iter_mut() {
-            let other_info = other.code_map.get(offset).unwrap();
-            result = result.combine(
-                info.before
-                    .join(&other_info.before)
-                    .combine(info.after.join(&other_info.after)),
-            );
+    fn from_full(
+        summary: BorrowInfo,
+        code_map: BTreeMap<CodeOffset, FullBorrowInfoAtCodeOffset>,
+        instrs: &[Bytecode],
+    ) -> Self {
+        Self {
+            summary,
+            code_map: code_map
+                .into_iter()
+                .filter(|(offset, _)| instruction_has_borrow_info(&instrs[*offset as usize]))
+                .map(|(offset, info)| (offset, info.saved()))
+                .collect(),
         }
-        result
     }
+
+    fn code_map(&self) -> &BTreeMap<CodeOffset, BorrowInfoAtCodeOffset> {
+        &self.code_map
+    }
+
+    fn join(&mut self, other: &Self) -> JoinResult {
+        self.summary.join(&other.summary)
+    }
+}
+
+pub(crate) fn instruction_has_borrow_info(bytecode: &Bytecode) -> bool {
+    matches!(
+        bytecode,
+        Bytecode::Assign(..)
+            | Bytecode::Call(..)
+            | Bytecode::Ret(..)
+            | Bytecode::Branch(..)
+            | Bytecode::Jump(..)
+            | Bytecode::VariantSwitch(..)
+            | Bytecode::Abort(..)
+            | Bytecode::SaveMem(..)
+            | Bytecode::Prop(..)
+    )
 }
 
 /// Borrow analysis processor.
@@ -479,11 +520,10 @@ impl FunctionTargetProcessor for BorrowAnalysisProcessor {
                     data.annotations
                         .get::<BorrowAnnotation>()
                         .unwrap()
-                        .code_map
+                        .code_map()
                         .values()
                         .flat_map(|info| {
-                            info.before
-                                .dying_nodes(&info.after)
+                            info.dying_nodes
                                 .iter()
                                 .flat_map(|(_, actions)| actions)
                                 .flatten()
@@ -705,7 +745,7 @@ impl<'a> BorrowAnalysis<'a> {
             let mut after = after.clone();
             before.consolidate();
             after.consolidate();
-            BorrowInfoAtCodeOffset { before, after }
+            FullBorrowInfoAtCodeOffset { before, after }
         });
         let mut summary = BorrowInfo::default();
         for (offs, code) in instrs.iter().enumerate() {
@@ -716,7 +756,7 @@ impl<'a> BorrowAnalysis<'a> {
             }
         }
         summary.consolidate();
-        BorrowAnnotation { summary, code_map }
+        BorrowAnnotation::from_full(summary, code_map, instrs)
     }
 
     fn borrow_node(&self, idx: TempIndex) -> BorrowNode {
@@ -911,7 +951,7 @@ impl TransferFunctions for BorrowAnalysis<'_> {
                             }
                         }
 
-                        let callee_annotation = get_custom_annotation_or_none(
+                        let callee_summary = get_custom_annotation_or_none(
                             callee_env,
                             &targs,
                             &srcs
@@ -920,6 +960,7 @@ impl TransferFunctions for BorrowAnalysis<'_> {
                                 .collect_vec(),
                             self.borrow_natives,
                         )
+                        .map(|annotation| annotation.summary)
                         .unwrap_or_else(|| {
                             let callee_info = if mid.qualified(*fid)
                                 == self.func_target.func_env.get_qualified_id()
@@ -941,11 +982,11 @@ impl TransferFunctions for BorrowAnalysis<'_> {
                             match callee_info {
                                 None => {
                                     // 1st iteration of the recursive case
-                                    BorrowAnnotation::default()
+                                    BorrowInfo::default()
                                 }
                                 Some(annotation) => {
                                     // non-recursive case or Nth iteration of fixedpoint (N >= 1)
-                                    annotation.clone()
+                                    annotation.summary.clone()
                                 }
                             }
                         });
@@ -953,7 +994,7 @@ impl TransferFunctions for BorrowAnalysis<'_> {
                         state.instantiate(
                             callee_env,
                             targs,
-                            &callee_annotation.summary,
+                            &callee_summary,
                             srcs,
                             dests,
                             Some(callee_env.get_qualified_id())
@@ -1009,12 +1050,10 @@ pub fn format_borrow_annotation(
     func_target: &FunctionTarget<'_>,
     code_offset: CodeOffset,
 ) -> Option<String> {
-    if let Some(BorrowAnnotation { code_map, .. }) =
-        func_target.get_annotations().get::<BorrowAnnotation>()
-    {
-        if let Some(map_at) = code_map.get(&code_offset) {
-            if !map_at.before.is_empty() {
-                return Some(map_at.before.borrow_info_str(func_target));
+    if let Some(annotation) = func_target.get_annotations().get::<BorrowAnnotation>() {
+        if let Some(map_at) = annotation.get_borrow_info_at(code_offset) {
+            if !map_at.dying_nodes.is_empty() {
+                return Some(format!("{:?}", map_at.dying_nodes));
             }
         }
     }

--- a/crates/move-stackless-bytecode/src/memory_instrumentation.rs
+++ b/crates/move-stackless-bytecode/src/memory_instrumentation.rs
@@ -11,7 +11,7 @@ use move_model::{
 };
 
 use crate::{
-    borrow_analysis::{BorrowAnnotation, WriteBackAction},
+    borrow_analysis::{instruction_has_borrow_info, BorrowAnnotation, WriteBackAction},
     exp_generator::ExpGenerator,
     function_data_builder::FunctionDataBuilder,
     function_target::FunctionData,
@@ -163,12 +163,20 @@ impl<'a> Instrumenter<'a> {
     fn memory_instrumentation(&mut self, code_offset: CodeOffset, bytecode: &Bytecode) {
         let param_count = self.builder.get_target().get_parameter_count();
 
+        if !instruction_has_borrow_info(bytecode) {
+            assert!(
+                self.borrow_annotation
+                    .get_borrow_info_at(code_offset)
+                    .is_none(),
+                "unexpected borrow info for bytecode offset {}",
+                code_offset
+            );
+            return;
+        }
         let borrow_annotation_at = self
             .borrow_annotation
             .get_borrow_info_at(code_offset)
-            .unwrap();
-        let before = &borrow_annotation_at.before;
-        let after = &borrow_annotation_at.after;
+            .expect("missing borrow info for bytecode that requires it");
 
         // Generate UnpackRef from Borrow instructions.
         if let Call(attr_id, dests, op, _, _) = bytecode {
@@ -180,8 +188,11 @@ impl<'a> Instrumenter<'a> {
                         .get_target()
                         .get_local_type(dests[0])
                         .to_owned();
-                    let node = BorrowNode::Reference(dests[0]);
-                    if self.is_pack_ref_ty(ty) && after.is_in_use(&node) {
+                    if self.is_pack_ref_ty(ty)
+                        && borrow_annotation_at
+                            .live_nodes_after
+                            .contains(&BorrowNode::Reference(dests[0]))
+                    {
                         self.builder.set_loc_from_attr(*attr_id);
                         self.builder.emit_with(|id| {
                             Bytecode::Call(id, vec![], Operation::UnpackRef, vec![dests[0]], None)
@@ -196,7 +207,7 @@ impl<'a> Instrumenter<'a> {
         let attr_id = bytecode.get_attr_id();
         self.builder.set_loc_from_attr(attr_id);
 
-        for (node, ancestors) in before.dying_nodes(after) {
+        for (node, ancestors) in &borrow_annotation_at.dying_nodes {
             // we only care about references that occurs in the function body
             let node_idx = match node {
                 BorrowNode::LocalRoot(..)
@@ -205,7 +216,7 @@ impl<'a> Instrumenter<'a> {
                     continue;
                 }
                 BorrowNode::Reference(idx) => {
-                    if idx < param_count {
+                    if *idx < param_count {
                         // NOTE: we have an entry-point assumption where a &mut parameter must
                         // have its data invariants hold. As a result, when we write-back the
                         // references, we should assert that the data invariant still hold.
@@ -214,15 +225,15 @@ impl<'a> Instrumenter<'a> {
                         // function body, i.e., by borrow local or borrow global. These cases
                         // are handled by the `pre_writeback_check_opt` (see below).
                         let target = self.builder.get_target();
-                        let ty = target.get_local_type(idx);
+                        let ty = target.get_local_type(*idx);
                         if self.is_pack_ref_ty(ty) {
                             self.builder.emit_with(|id| {
-                                Bytecode::Call(id, vec![], Operation::PackRefDeep, vec![idx], None)
+                                Bytecode::Call(id, vec![], Operation::PackRefDeep, vec![*idx], None)
                             });
                         }
                         continue;
                     }
-                    idx
+                    *idx
                 }
                 BorrowNode::ReturnPlaceholder(..) => {
                     unreachable!("Unexpected placeholder borrow node");
@@ -333,15 +344,15 @@ impl<'a> Instrumenter<'a> {
                     });
                     if self.prover_options.debug_trace {
                         // add a trace for written back value if it's a user variable.
-                        match action.dst {
+                        match &action.dst {
                             BorrowNode::LocalRoot(temp) | BorrowNode::Reference(temp) => {
-                                if temp < self.builder.fun_env.get_local_count() {
+                                if *temp < self.builder.fun_env.get_local_count() {
                                     self.builder.emit_with(|id| {
                                         Bytecode::Call(
                                             id,
                                             vec![],
-                                            Operation::TraceLocal(temp),
-                                            vec![temp],
+                                            Operation::TraceLocal(*temp),
+                                            vec![*temp],
                                             None,
                                         )
                                     });


### PR DESCRIPTION
Large Navi lending_core test functions OOM because the borrow analysis retained a full before/after BorrowInfo snapshot at every bytecode offset. Borrow edges are monotone and cumulative, so retaining full per-offset graphs grows quickly and dominates memory.

Keep the intraprocedural dataflow state and full before/after per-offset map transient while computing a function. The stored BorrowAnnotation now keeps the callee summary plus only the data memory instrumentation needs: live_nodes_after for UnpackRef emission and precomputed dying_nodes for PackRef/WriteBack emission. Offsets are saved only for bytecodes that can require borrow instrumentation, and consumers fail explicitly if that bytecode-level contract is violated.

SCC convergence compares function summaries, which are the interprocedural data needed by callers. Finalize still drops LiveVarAnnotation before later processors run.

Verified with cargo check -p move-stackless-bytecode and Navi lending_core --test generate-only through lean-backend: 2.55 GiB peak sampled tree RSS.