### PR TITLE
Add run_on="lean" spec attribute: Lean-only spec, Boogie trusts/skips

### DIFF
--- a/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/bytecode_translator.rs
@@ -183,6 +183,11 @@ impl<'env> BoogieTranslator<'env> {
             })
     }
 
+    /// Like `is_verified_spec`, minus `run_on="lean"` specs (Boogie trusts those).
+    fn is_boogie_verified_spec(&self, qid: &QualifiedId<FunId>) -> bool {
+        self.targets.is_verified_spec(qid) && !self.targets.lean_proven_specs().contains(qid)
+    }
+
     /// Generate a Boogie variable name for a per-spec ignore_aborts flag.
     fn asserts_of_var_name(spec_env: &FunctionEnv) -> String {
         format!(
@@ -741,7 +746,7 @@ impl<'env> BoogieTranslator<'env> {
             .scenario_specs()
             .contains(&fun_env.get_qualified_id())
         {
-            if self.targets.is_verified_spec(&fun_env.get_qualified_id())
+            if self.is_boogie_verified_spec(&fun_env.get_qualified_id())
                 && self.targets.has_target(
                     fun_env,
                     &FunctionVariant::Verification(VerificationFlavor::Regular),
@@ -779,7 +784,7 @@ impl<'env> BoogieTranslator<'env> {
         self.translate_function_style(fun_env, FunctionTranslationStyle::Aborts);
         self.translate_function_style(fun_env, FunctionTranslationStyle::Opaque);
 
-        if self.targets.is_verified_spec(&fun_env.get_qualified_id()) {
+        if self.is_boogie_verified_spec(&fun_env.get_qualified_id()) {
             self.translate_function_style(fun_env, FunctionTranslationStyle::Default);
             self.translate_function_style(fun_env, FunctionTranslationStyle::Asserts);
             self.translate_function_style(fun_env, FunctionTranslationStyle::SpecNoAbortCheck);

--- a/crates/move-stackless-bytecode/src/function_target_pipeline.rs
+++ b/crates/move-stackless-bytecode/src/function_target_pipeline.rs
@@ -351,6 +351,10 @@ impl FunctionTargetsHolder {
         self.is_spec(id) && !self.no_verify_specs().contains(id)
     }
 
+    pub fn lean_proven_specs(&self) -> BTreeSet<QualifiedId<FunId>> {
+        self.package_targets.lean_proven_specs()
+    }
+
     pub fn is_scenario_spec(&self, id: &QualifiedId<FunId>) -> bool {
         self.package_targets.scenario_specs().contains(id)
     }

--- a/crates/move-stackless-bytecode/src/package_targets.rs
+++ b/crates/move-stackless-bytecode/src/package_targets.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 /// Valid values for the `run_on` attribute in `#[spec(prove, run_on="...")]`.
-pub const VALID_RUN_ON_VALUES: &[&str] = &["local", "cloud", "boogie"];
+pub const VALID_RUN_ON_VALUES: &[&str] = &["local", "cloud", "boogie", "lean"];
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ModuleExternalSpecAttribute {
@@ -421,7 +421,13 @@ impl PackageTargets {
             }
 
             if let Some(run_on_value) = run_on {
-                if VALID_RUN_ON_VALUES.contains(&run_on_value.as_str()) {
+                if !*prove || skip.is_some() {
+                    env.diag(
+                        Severity::Error,
+                        &func_env.get_loc(),
+                        "`run_on` requires `prove` (it is meaningless on a non-prove / skipped spec)",
+                    );
+                } else if VALID_RUN_ON_VALUES.contains(&run_on_value.as_str()) {
                     self.spec_run_on
                         .insert(func_env.get_qualified_id(), run_on_value.clone());
                 } else {
@@ -1090,6 +1096,15 @@ impl PackageTargets {
             .collect()
     }
 
+    /// Mirror of `boogie_proven_specs` for `run_on="lean"` (proven only by Lean).
+    pub fn lean_proven_specs(&self) -> BTreeSet<QualifiedId<FunId>> {
+        self.spec_run_on
+            .iter()
+            .filter(|(_, value)| value.as_str() == "lean")
+            .map(|(qid, _)| *qid)
+            .collect()
+    }
+
     pub fn loop_invariant_candidates(
         &self,
     ) -> &BTreeMap<QualifiedId<FunId>, Vec<(QualifiedId<FunId>, usize)>> {
@@ -1147,5 +1162,80 @@ impl PackageTargets {
         &self,
     ) -> &BTreeMap<QualifiedId<FunId>, BTreeSet<QualifiedId<FunId>>> {
         &self.spec_uninterpreted_functions
+    }
+
+    /// Empty `PackageTargets` carrying just `spec_run_on`, for filter tests.
+    #[cfg(test)]
+    fn for_test_with_run_on(spec_run_on: BTreeMap<QualifiedId<FunId>, String>) -> Self {
+        Self {
+            target_specs: BTreeSet::new(),
+            abort_check_functions: BTreeSet::new(),
+            pure_functions: BTreeSet::new(),
+            pure_callees: BTreeSet::new(),
+            axiom_functions: BTreeSet::new(),
+            target_no_abort_check_functions: BTreeSet::new(),
+            skipped_specs: BTreeMap::new(),
+            no_verify_specs: BTreeSet::new(),
+            ignore_aborts: BTreeSet::new(),
+            omit_opaque_specs: BTreeSet::new(),
+            focus_specs: BTreeSet::new(),
+            scenario_specs: BTreeSet::new(),
+            globally_uninterpreted_functions: BTreeSet::new(),
+            spec_uninterpreted_functions: BTreeMap::new(),
+            spec_interpreted_functions: BTreeMap::new(),
+            spec_boogie_options: BTreeMap::new(),
+            spec_timeouts: BTreeMap::new(),
+            spec_run_on,
+            loop_invariant_candidates: BTreeMap::new(),
+            module_external_attributes: BTreeMap::new(),
+            function_external_attributes: BTreeMap::new(),
+            module_extra_bpl: BTreeMap::new(),
+            function_extra_bpl: BTreeMap::new(),
+            prelude_extra_exists: false,
+            all_specs: BTreeMap::new(),
+            all_datatypes_invs: BTreeMap::new(),
+            system_specs: BTreeSet::new(),
+            filter: TargetFilterOptions::default(),
+            allow_focus_attr: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_model::symbol::SymbolPool;
+
+    fn qid(pool: &SymbolPool, name: &str) -> QualifiedId<FunId> {
+        ModuleId::new(0).qualified(FunId::new(pool.make(name)))
+    }
+
+    #[test]
+    fn lean_is_a_valid_run_on_value() {
+        assert!(VALID_RUN_ON_VALUES.contains(&"lean"));
+    }
+
+    #[test]
+    fn lean_and_boogie_proven_specs_partition_by_run_on_value() {
+        let pool = SymbolPool::new();
+        let lean_spec = qid(&pool, "lean_spec");
+        let boogie_spec = qid(&pool, "boogie_spec");
+        let local_spec = qid(&pool, "local_spec");
+
+        let mut spec_run_on = BTreeMap::new();
+        spec_run_on.insert(lean_spec, "lean".to_string());
+        spec_run_on.insert(boogie_spec, "boogie".to_string());
+        spec_run_on.insert(local_spec, "local".to_string());
+
+        let targets = PackageTargets::for_test_with_run_on(spec_run_on);
+
+        let lean = targets.lean_proven_specs();
+        assert_eq!(lean, BTreeSet::from([lean_spec]));
+
+        let boogie = targets.boogie_proven_specs();
+        assert_eq!(boogie, BTreeSet::from([boogie_spec]));
+
+        assert!(!lean.contains(&boogie_spec));
+        assert!(!boogie.contains(&lean_spec));
     }
 }


### PR DESCRIPTION
Introduce `#[spec(prove, run_on="lean")]`, the exact mirror of the existing `run_on="boogie"`: the spec is verified only by the Lean backend, and the Boogie backend trusts/skips it (emits no verification obligation). On the Lean side no change is needed -- a run_on="lean" spec stays in target_specs (is_verified_spec) and out of both boogie_proven_specs() and no_verify_specs(), so the Lean pipeline gives it a normal prove obligation.

Changes:
- package_targets.rs:
  - Add "lean" to VALID_RUN_ON_VALUES.
  - Add PackageTargets::lean_proven_specs() mirroring boogie_proven_specs().
  - check_spec_scope: `run_on` now requires `prove` and is incompatible with `skip`; otherwise emit a Severity::Error and do not record the run_on value.
- function_target_pipeline.rs: expose lean_proven_specs() on FunctionTargetsHolder, delegating to PackageTargets.
- bytecode_translator.rs (Boogie backend, local): add is_boogie_verified_spec helper (is_verified_spec && !lean_proven_specs().contains) and use it at the two sites that gate emitting a Verification-variant obligation (translate_spec's normal and scenario-spec paths), so run_on="lean" specs get no Boogie obligation while their opaque/aborts summaries are still emitted for callers. The shared is_verified_spec is left untouched so the Lean pipeline still roots these specs.
- Unit tests for VALID_RUN_ON_VALUES and the lean/boogie partition.