### PR TITLE
Replace `spec_only` with `mode(spec)` and `ext(spec)`

### DIFF
--- a/.claude/skills/sui-prover/SKILL.md
+++ b/.claude/skills/sui-prover/SKILL.md
@@ -191,7 +191,7 @@ module amm_specs::simple_lp_specs;
 use amm::simple_lp::{LP, Pool};
 use sui::balance::Balance;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{clone, ensures, requires};
 
 #[spec(prove, target = amm::simple_lp::withdraw)]
@@ -337,7 +337,7 @@ while (i < n) {
 
 **External loop invariants** - Define as separate functions (alternative to inline):
 ```move
-#[spec_only(loop_inv(target = sum_to_n_spec))]
+#[mode(spec), ext(spec(loop_inv(target = sum_to_n_spec)))]
 #[ext(no_abort)]
 fun sum_loop_inv(i: u64, n: u64, sum: u128): bool {
     i <= n && sum == (i as u128) * ((i as u128) + 1) / 2
@@ -362,7 +362,7 @@ ensures(module::get_value(storage, key) == value);
 
 **Extra BPL prelude files** - When the prover fails with `use of undeclared function: $X_module_native_func$pure`, create a `.bpl` prelude file with the missing function definition:
 ```move
-#[spec_only(extra_bpl = b"mymodule_prelude.bpl")]
+#[mode(spec), ext(spec(extra_bpl = b"mymodule_prelude.bpl"))]
 module project_specs::mymodule;
 ```
 Place the BPL file in the same directory as the spec module.
@@ -375,7 +375,7 @@ fun public_transfer_spec<T: key + store>(obj: T, recipient: address) { ... }
 
 **Ghost variables for `transfer::public_transfer`** - When a spec involves `transfer::public_transfer` (directly or indirectly), declare ghost variables:
 ```move
-#[spec_only]
+#[mode(spec)]
 use specs::transfer_spec::{SpecTransferAddress, SpecTransferAddressExists};
 
 #[spec(prove, target = project::example::func_that_transfers)]

--- a/.claude/skills/sui-prover/spec-reference.md
+++ b/.claude/skills/sui-prover/spec-reference.md
@@ -43,14 +43,14 @@ Ghost variables are spec-only globals for propagating information between specif
 Ghost variables are declared with two type-level arguments: a key type and a value type. The key is usually a user struct or a spec-only struct:
 
 ```move
-#[spec_only]
+#[mode(spec)]
 public struct MyGhostKey {}
 ```
 
 ### Declaring and Reading
 
 ```move
-#[spec_only]
+#[mode(spec)]
 use prover::ghost::{declare_global, global};
 
 #[spec(prove)]
@@ -66,7 +66,7 @@ fun ghost_example_spec() {
 ### Mutable Ghost Variables
 
 ```move
-#[spec_only]
+#[mode(spec)]
 use prover::ghost::{declare_global_mut, borrow_mut, global};
 
 #[spec(prove)]
@@ -243,9 +243,9 @@ public fun get_field_name(self: &MyStruct): u64 {
 }
 ```
 
-### `#[spec_only(...)]` - Specification Attributes
+### `#[mode(spec), ext(spec(...))]` - Specification Attributes
 
-Use parameterized `spec_only` attributes for axioms, datatype invariants, loop invariants, spec inclusion, and extra Boogie files.
+Mark spec-only code with `#[mode(spec)]`. Parameterized spec attributes (axioms, datatype invariants, loop invariants, spec inclusion, and extra Boogie files) go in a companion `#[ext(spec(...))]` attribute, which requires `#[mode(spec)]` on the same item.
 
 | Parameter | Description |
 |-----------|-------------|
@@ -254,21 +254,23 @@ Use parameterized `spec_only` attributes for axioms, datatype invariants, loop i
 | `(loop_inv(target = <FUNC>))` | External loop invariant |
 | `(loop_inv(target = <FUNC>, label = N))` | Loop invariant with label |
 | `(include = <PATH>)` | Include spec module |
+| `(include(a = <PATH>, b = <PATH>))` | Include multiple spec modules (inner keys arbitrary but unique) |
 | `(extra_bpl = b"<file>")` | Load extra Boogie code |
+| `(extra_bpl(a = b"<file>", b = b"<file>"))` | Load multiple extra Boogie files (inner keys arbitrary but unique) |
 
 Examples:
 ```move
 use project::numbers::PositiveNumber;
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
 fun sqrt_axiom(x: u64): u64 { ... }
 
-#[spec_only(inv_target = project::numbers::PositiveNumber)]
+#[mode(spec), ext(spec(inv_target = project::numbers::PositiveNumber))]
 public fun PositiveNumber_inv(self: &PositiveNumber): bool {
     self.value() > 0
 }
 
-#[spec_only(loop_inv(target = my_func_spec))]
+#[mode(spec), ext(spec(loop_inv(target = my_func_spec)))]
 fun loop_inv_for_my_func() { }
 ```
 
@@ -302,10 +304,10 @@ fun sum_to_n_spec(n: u64): u128 {
 
 ### External Loop Invariants
 
-Alternatively, define loop invariants as separate functions with `#[spec_only(loop_inv(target = ...))]`. The invariant function returns a boolean conjunction of all conditions.
+Alternatively, define loop invariants as separate functions with `#[mode(spec), ext(spec(loop_inv(target = ...)))]`. The invariant function returns a boolean conjunction of all conditions.
 
 ```move
-#[spec_only(loop_inv(target = sum_to_n_spec))]
+#[mode(spec), ext(spec(loop_inv(target = sum_to_n_spec)))]
 #[ext(no_abort)]
 fun sum_loop_inv(i: u64, n: u64, sum: u128): bool {
     i <= n && sum == (i as u128) * ((i as u128) + 1) / 2
@@ -332,11 +334,11 @@ fun sum_to_n_spec(n: u64): u128 {
 - For multiple loops, use `label = N` (0-indexed):
 
 ```move
-#[spec_only(loop_inv(target = my_spec, label = 0))]
+#[mode(spec), ext(spec(loop_inv(target = my_spec, label = 0)))]
 #[ext(no_abort)]
 fun first_loop_inv(...): bool { ... }
 
-#[spec_only(loop_inv(target = my_spec, label = 1))]
+#[mode(spec), ext(spec(loop_inv(target = my_spec, label = 1)))]
 #[ext(no_abort)]
 fun second_loop_inv(...): bool { ... }
 ```
@@ -364,7 +366,7 @@ module project_specs::number_specs;
 
 use project::numbers::PositiveNumber;
 
-#[spec_only(inv_target = project::numbers::PositiveNumber)]
+#[mode(spec), ext(spec(inv_target = project::numbers::PositiveNumber))]
 public fun PositiveNumber_inv(self: &PositiveNumber): bool {
     self.value() > 0
 }

--- a/README.MD
+++ b/README.MD
@@ -104,7 +104,7 @@ module amm_specs::simple_lp_specs;
 use amm::simple_lp::{LP, Pool};
 use sui::balance::Balance;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{clone, ensures, requires};
 
 #[spec(prove, target = amm::simple_lp::withdraw)]

--- a/crates/move-prover-boogie-backend/src/boogie_backend/lib.rs
+++ b/crates/move-prover-boogie-backend/src/boogie_backend/lib.rs
@@ -536,7 +536,7 @@ pub fn add_prelude(
         if seen_bpl.insert(*content) {
             emitln!(
                 writer,
-                "\n// ** Extra BPL from #[spec] or #[spec_only] attribute\n"
+                "\n// ** Extra BPL from #[spec] or #[ext(spec(extra_bpl = ...))] attribute\n"
             );
             emitln!(writer, content);
         }

--- a/crates/move-stackless-bytecode/src/attr_query.rs
+++ b/crates/move-stackless-bytecode/src/attr_query.rs
@@ -1,0 +1,353 @@
+//! Helpers for reading prover-relevant attributes from the compiled model.
+
+use codespan_reporting::diagnostic::Severity;
+use move_compiler::{
+    expansion::ast::{Attributes, ModuleAccess, ModuleIdent, Value_},
+    shared::known_attributes::{
+        AttributeKind_, ExternalAttribute, ExternalAttributeEntry_, ExternalAttributeValue_,
+        KnownAttribute, ModeAttribute,
+    },
+};
+use move_model::model::{FunctionEnv, GlobalEnv, Loc, ModuleEnv};
+
+/// The compiler mode that marks spec-only code: `#[mode(spec)]`.
+pub const SPEC_MODE: &str = "spec";
+
+/// The realized form of an `#[ext(spec(...))]` annotation.
+#[derive(Debug, Clone, Default)]
+pub struct SpecInfo {
+    pub role: Option<SpecRole>,
+    pub explicit_spec_modules: Vec<ModuleIdent>,
+    pub explicit_specs: Vec<ModuleAccess>,
+    pub extra_bpl: Vec<String>,
+}
+
+/// The role an `#[ext(spec(...))]` annotation assigns to its item; at most one
+/// may be given.
+#[derive(Debug, Clone)]
+pub enum SpecRole {
+    Axiom,
+    Invariant {
+        target: ModuleAccess,
+    },
+    /// A missing target is diagnosed at the use site.
+    LoopInvariant {
+        target: Option<ModuleAccess>,
+        label: usize,
+    },
+}
+
+/// Prover flags carried by a plain `#[ext(...)]` attribute.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExtFlags {
+    pub no_abort: bool,
+    pub pure: bool,
+    pub uninterpreted: bool,
+}
+
+/// Access to the `#[mode(spec)]` marker and the realized `#[ext(spec(...))]`
+/// annotation on model items.
+pub trait SpecModeAnnotated {
+    fn global_env(&self) -> &GlobalEnv;
+    fn loc(&self) -> Loc;
+    fn attributes(&self) -> &Attributes;
+    fn item_name(&self) -> String;
+
+    fn is_spec_mode(&self) -> bool {
+        matches!(
+            self.attributes().get_(&AttributeKind_::Mode).map(|attr| &attr.value),
+            Some(KnownAttribute::Mode(ModeAttribute { modes }))
+                if modes.contains_(&SPEC_MODE.into())
+        )
+    }
+
+    /// The realized `#[ext(spec(...))]` annotation, if present. Reports an error
+    /// and returns `None` when the annotation appears without `#[mode(spec)]`.
+    fn get_spec_info(&self) -> Option<SpecInfo> {
+        let env = self.global_env();
+        let loc = self.loc();
+        let info = parse_spec_info(env, &loc, self.attributes())?;
+        if !self.is_spec_mode() {
+            attr_error(
+                env,
+                &loc,
+                &format!(
+                    "#[ext(spec(...))] on '{}' requires #[mode(spec)]",
+                    self.item_name()
+                ),
+            );
+            return None;
+        }
+        Some(info)
+    }
+}
+
+impl SpecModeAnnotated for FunctionEnv<'_> {
+    fn global_env(&self) -> &GlobalEnv {
+        self.module_env.env
+    }
+    fn loc(&self) -> Loc {
+        self.get_loc()
+    }
+    fn attributes(&self) -> &Attributes {
+        self.get_toplevel_attributes()
+    }
+    fn item_name(&self) -> String {
+        self.get_full_name_str()
+    }
+}
+
+impl SpecModeAnnotated for ModuleEnv<'_> {
+    fn global_env(&self) -> &GlobalEnv {
+        self.env
+    }
+    fn loc(&self) -> Loc {
+        self.get_loc()
+    }
+    fn attributes(&self) -> &Attributes {
+        self.get_toplevel_attributes()
+    }
+    fn item_name(&self) -> String {
+        self.get_full_name_str()
+    }
+}
+
+/// Collects the prover flags from an `#[ext(...)]` attribute.
+pub fn get_ext_flags(attrs: &Attributes) -> ExtFlags {
+    let mut flags = ExtFlags::default();
+    let Some(entries) = ext_entries(attrs) else {
+        return flags;
+    };
+    for entry in entries {
+        match entry.name().value.as_str() {
+            "no_abort" => flags.no_abort = true,
+            "pure" => flags.pure = true,
+            "uninterpreted" => flags.uninterpreted = true,
+            _ => (),
+        }
+    }
+    flags
+}
+
+fn ext_entries(attrs: &Attributes) -> Option<impl Iterator<Item = &ExternalAttributeEntry_>> {
+    match attrs
+        .get_(&AttributeKind_::External)
+        .map(|attr| &attr.value)
+    {
+        Some(KnownAttribute::External(ExternalAttribute { attrs })) => {
+            Some(attrs.into_iter().map(|entry| &entry.2.value))
+        }
+        _ => None,
+    }
+}
+
+fn attr_error(env: &GlobalEnv, loc: &Loc, msg: &str) {
+    env.diag(Severity::Error, loc, msg);
+}
+
+fn parse_spec_info(env: &GlobalEnv, loc: &Loc, attrs: &Attributes) -> Option<SpecInfo> {
+    let spec_entry = ext_entries(attrs)?.find(|entry| entry.name().value.as_str() == "spec")?;
+    let ExternalAttributeEntry_::Parameterized(_, entries) = spec_entry else {
+        attr_error(
+            env,
+            loc,
+            "`spec` in #[ext(...)] expects parameters, e.g. `ext(spec(axiom))`",
+        );
+        return None;
+    };
+
+    let mut info = SpecInfo::default();
+    for entry in entries.into_iter().map(|entry| &entry.2.value) {
+        match entry.name().value.as_str() {
+            "axiom" => match entry {
+                ExternalAttributeEntry_::Name(_) => set_role(env, loc, &mut info, SpecRole::Axiom),
+                _ => attr_error(env, loc, "`axiom` in #[ext(spec(...))] takes no value"),
+            },
+            "inv_target" => {
+                if let Some(target) = expect_path(env, loc, entry, "inv_target") {
+                    set_role(env, loc, &mut info, SpecRole::Invariant { target });
+                }
+            }
+            "loop_inv" => {
+                if let Some(role) = parse_loop_inv(env, loc, entry) {
+                    set_role(env, loc, &mut info, role);
+                }
+            }
+            "include" => parse_include(env, loc, entry, &mut info),
+            "extra_bpl" => parse_extra_bpl(env, loc, entry, &mut info),
+            other => attr_error(
+                env,
+                loc,
+                &format!("unknown #[ext(spec(...))] parameter '{}'", other),
+            ),
+        }
+    }
+    Some(info)
+}
+
+fn set_role(env: &GlobalEnv, loc: &Loc, info: &mut SpecInfo, role: SpecRole) {
+    if info.role.is_some() {
+        attr_error(
+            env,
+            loc,
+            "at most one of `axiom`, `inv_target`, and `loop_inv` may be given in #[ext(spec(...))]",
+        );
+    } else {
+        info.role = Some(role);
+    }
+}
+
+fn parse_loop_inv(env: &GlobalEnv, loc: &Loc, entry: &ExternalAttributeEntry_) -> Option<SpecRole> {
+    let ExternalAttributeEntry_::Parameterized(_, entries) = entry else {
+        attr_error(
+            env,
+            loc,
+            "`loop_inv` in #[ext(spec(...))] expects parameters, e.g. `loop_inv(target = f)`",
+        );
+        return None;
+    };
+    let mut target = None;
+    let mut label = 0;
+    for entry in entries.into_iter().map(|entry| &entry.2.value) {
+        match entry.name().value.as_str() {
+            "target" => target = expect_path(env, loc, entry, "target"),
+            "label" => label = expect_number(env, loc, entry, "label").unwrap_or(0),
+            other => attr_error(
+                env,
+                loc,
+                &format!("unknown `loop_inv` parameter '{}'", other),
+            ),
+        }
+    }
+    Some(SpecRole::LoopInvariant { target, label })
+}
+
+/// `include = p` gives one path; `include(a = p1, b = p2)` gives several, since
+/// entry names within one attribute list must be unique. The same holds for
+/// `extra_bpl`.
+fn entry_values<'a>(
+    env: &GlobalEnv,
+    loc: &Loc,
+    entry: &'a ExternalAttributeEntry_,
+    what: &str,
+) -> Vec<&'a ExternalAttributeValue_> {
+    match entry {
+        ExternalAttributeEntry_::Assigned(_, value) => vec![&value.value],
+        ExternalAttributeEntry_::Parameterized(_, entries) => {
+            let mut values = vec![];
+            for entry in entries.into_iter().map(|entry| &entry.2.value) {
+                match entry {
+                    ExternalAttributeEntry_::Assigned(_, value) => values.push(&value.value),
+                    _ => attr_error(
+                        env,
+                        loc,
+                        &format!("`{what}` in #[ext(spec(...))] expects a path"),
+                    ),
+                }
+            }
+            values
+        }
+        ExternalAttributeEntry_::Name(_) => {
+            attr_error(
+                env,
+                loc,
+                &format!("`{what}` in #[ext(spec(...))] expects a path"),
+            );
+            vec![]
+        }
+    }
+}
+
+fn parse_include(env: &GlobalEnv, loc: &Loc, entry: &ExternalAttributeEntry_, info: &mut SpecInfo) {
+    for value in entry_values(env, loc, entry, "include") {
+        match value {
+            ExternalAttributeValue_::Module(mi) => info.explicit_spec_modules.push(*mi),
+            ExternalAttributeValue_::ModuleAccess(ma) => info.explicit_specs.push(*ma),
+            _ => attr_error(
+                env,
+                loc,
+                "`include` in #[ext(spec(...))] expects a module or function path, \
+                 e.g. `include = 0x42::m` or `include = 0x42::m::f`",
+            ),
+        }
+    }
+}
+
+fn parse_extra_bpl(
+    env: &GlobalEnv,
+    loc: &Loc,
+    entry: &ExternalAttributeEntry_,
+    info: &mut SpecInfo,
+) {
+    for value in entry_values(env, loc, entry, "extra_bpl") {
+        match expect_bytestring(value) {
+            Some(path) => info.extra_bpl.push(path),
+            None => attr_error(
+                env,
+                loc,
+                "`extra_bpl` in #[ext(spec(...))] expects a bytestring path, \
+                 e.g. `extra_bpl = b\"file.bpl\"`",
+            ),
+        }
+    }
+}
+
+fn expect_path(
+    env: &GlobalEnv,
+    loc: &Loc,
+    entry: &ExternalAttributeEntry_,
+    what: &str,
+) -> Option<ModuleAccess> {
+    if let ExternalAttributeEntry_::Assigned(_, value) = entry {
+        if let ExternalAttributeValue_::ModuleAccess(ma) = &value.value {
+            return Some(*ma);
+        }
+    }
+    attr_error(
+        env,
+        loc,
+        &format!(
+            "`{what}` in #[ext(spec(...))] expects an assigned path, e.g. `{what} = 0x42::m::f`"
+        ),
+    );
+    None
+}
+
+fn expect_number(
+    env: &GlobalEnv,
+    loc: &Loc,
+    entry: &ExternalAttributeEntry_,
+    what: &str,
+) -> Option<usize> {
+    if let ExternalAttributeEntry_::Assigned(_, value) = entry {
+        if let ExternalAttributeValue_::Value(v) = &value.value {
+            let n = match &v.value {
+                Value_::InferredNum(n) | Value_::U256(n) => n.to_string().parse().ok(),
+                Value_::U8(n) => Some(*n as usize),
+                Value_::U16(n) => Some(*n as usize),
+                Value_::U32(n) => Some(*n as usize),
+                Value_::U64(n) => usize::try_from(*n).ok(),
+                Value_::U128(n) => usize::try_from(*n).ok(),
+                _ => None,
+            };
+            if n.is_some() {
+                return n;
+            }
+        }
+    }
+    attr_error(
+        env,
+        loc,
+        &format!("`{what}` in `loop_inv` expects a number, e.g. `{what} = 0`"),
+    );
+    None
+}
+
+fn expect_bytestring(value: &ExternalAttributeValue_) -> Option<String> {
+    if let ExternalAttributeValue_::Value(v) = value {
+        if let Value_::Bytearray(bytes) | Value_::InferredString(bytes) = &v.value {
+            return String::from_utf8(bytes.clone()).ok();
+        }
+    }
+    None
+}

--- a/crates/move-stackless-bytecode/src/function_stats.rs
+++ b/crates/move-stackless-bytecode/src/function_stats.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for ProofStatus {
     }
 }
 
-/// Checks if a function has a specific attribute (e.g., "spec_only", "test_only").
+/// Checks if a function has a specific attribute (e.g., "test_only").
 fn has_attribute(func_env: &FunctionEnv, attr_name: &str) -> bool {
     func_env.get_attributes().iter().any(|attr| {
         matches!(
@@ -44,8 +44,7 @@ fn has_attribute(func_env: &FunctionEnv, attr_name: &str) -> bool {
 ///
 /// Filters out:
 /// - Non-public and non-entry functions
-/// - Functions with `spec_only` attribute
-/// - Functions with `test_only` attribute
+/// - Functions with any `mode` attribute (e.g. `#[mode(spec)]`, `#[test_only]`)
 /// - Spec functions themselves
 fn should_include_function(func_env: &FunctionEnv, targets: &PackageTargets) -> bool {
     if func_env
@@ -59,6 +58,7 @@ fn should_include_function(func_env: &FunctionEnv, targets: &PackageTargets) -> 
     if func_env.visibility() != Visibility::Public && !func_env.is_entry() {
         return false;
     }
+    // Unmigrated dependencies (e.g. the system framework packages) still carry `#[spec_only]`.
     if func_env
         .get_toplevel_attributes()
         .get_(&AttributeKind_::SpecOnly)

--- a/crates/move-stackless-bytecode/src/lib.rs
+++ b/crates/move-stackless-bytecode/src/lib.rs
@@ -12,6 +12,7 @@ pub mod access_path;
 pub mod access_path_trie;
 pub mod annotations;
 pub mod ast;
+pub mod attr_query;
 pub mod axiom_function_analysis;
 pub mod borrow_analysis;
 pub mod clean_and_optimize;

--- a/crates/move-stackless-bytecode/src/package_targets.rs
+++ b/crates/move-stackless-bytecode/src/package_targets.rs
@@ -1,16 +1,15 @@
+use crate::attr_query::{get_ext_flags, SpecModeAnnotated, SpecRole};
 use crate::target_filter::TargetFilterOptions;
 use codespan_reporting::diagnostic::Severity;
 use move_binary_format::file_format::FunctionHandleIndex;
 use move_compiler::{
-    expansion::ast::{ModuleAccess, ModuleAccess_, ModuleIdent_},
-    shared::known_attributes::{
-        AttributeKind_, ExternalAttribute, KnownAttribute, VerificationAttribute,
-    },
+    expansion::ast::{Attributes, ModuleAccess, ModuleAccess_, ModuleIdent_},
+    shared::known_attributes::{AttributeKind_, KnownAttribute, VerificationAttribute},
 };
 use move_ir_types::location::Spanned;
 use move_model::{
     ast::ModuleName,
-    model::{DatatypeId, FunId, FunctionEnv, GlobalEnv, ModuleEnv, ModuleId, QualifiedId},
+    model::{DatatypeId, FunId, FunctionEnv, GlobalEnv, Loc, ModuleEnv, ModuleId, QualifiedId},
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -268,11 +267,24 @@ impl PackageTargets {
         // Phase 1: Collect all attributes except uninterpreted
         // This ensures pure_functions is populated before we validate uninterpreted targets
         for module_env in env.get_modules() {
+            let is_target = module_env.is_target();
             for func_env in module_env.get_functions() {
+                Self::check_deprecated_spec_only(
+                    env,
+                    func_env.get_toplevel_attributes(),
+                    &func_env.get_loc(),
+                    is_target,
+                );
                 self.check_spec_scope(&func_env);
-                self.check_spec_only_scope(&func_env);
+                self.check_spec_mode_scope(&func_env);
                 self.check_abort_check_scope(&func_env);
             }
+            Self::check_deprecated_spec_only(
+                env,
+                module_env.get_toplevel_attributes(),
+                &module_env.get_loc(),
+                is_target,
+            );
             self.handle_module_explicit_spec_attributes(&module_env);
         }
 
@@ -294,102 +306,103 @@ impl PackageTargets {
         }
     }
 
-    fn check_spec_only_scope(&mut self, func_env: &FunctionEnv) {
-        if let Some(KnownAttribute::Verification(VerificationAttribute::SpecOnly {
-            inv_target,
-            loop_inv,
-            explicit_spec_modules: _,
-            explicit_specs: _,
-            axiom,
-            extra_bpl,
-        })) = func_env
-            .get_toplevel_attributes()
-            .get_(&AttributeKind_::SpecOnly)
-            .map(|attr| &attr.value)
-        {
-            if func_env.get_name_str().contains("type_inv") {
-                return;
-            }
+    /// Reports an error for the removed `#[spec_only]` attribute.
+    fn check_deprecated_spec_only(env: &GlobalEnv, attrs: &Attributes, loc: &Loc, is_target: bool) {
+        if is_target && attrs.get_(&AttributeKind_::SpecOnly).is_some() {
+            env.diag(
+                Severity::Error,
+                loc,
+                "#[spec_only] is no longer supported; use #[mode(spec)] \
+                 (move parameters into #[ext(spec(...))])",
+            );
+        }
+    }
 
-            let env = func_env.module_env.env;
+    /// Resolves a `ModuleAccess` from an attribute into its module and member name.
+    fn resolve_attr_target<'env>(
+        func_env: &FunctionEnv<'env>,
+        ma: &ModuleAccess,
+        target_kind: &str,
+    ) -> Option<(ModuleEnv<'env>, String)> {
+        let env = func_env.module_env.env;
+        let Some((module_name, member_name)) = Self::parse_module_access(ma, &func_env.module_env)
+        else {
+            env.diag(
+                Severity::Error,
+                &func_env.get_loc(),
+                &format!(
+                    "Error parsing module path '{}'",
+                    func_env.module_env.get_full_name_str()
+                ),
+            );
+            return None;
+        };
+        let Some(module_env) = env.find_module(&module_name) else {
+            env.diag(
+                Severity::Error,
+                &func_env.get_loc(),
+                &format!(
+                    "{target_kind} module not found for path '{}'",
+                    module_name.display(env.symbol_pool())
+                ),
+            );
+            return None;
+        };
+        Some((module_env, member_name))
+    }
 
-            if *axiom {
+    fn check_spec_mode_scope(&mut self, func_env: &FunctionEnv) {
+        let env = func_env.module_env.env;
+        let info = func_env.get_spec_info();
+        if !func_env.is_spec_mode() {
+            return;
+        }
+        let info = info.unwrap_or_default();
+
+        if let Some(content) = Self::validate_and_read_extra_bpl(
+            env,
+            &func_env.get_loc(),
+            func_env.module_env.get_source_path(),
+            &info.extra_bpl,
+        ) {
+            self.function_extra_bpl
+                .insert(func_env.get_qualified_id(), content);
+        }
+
+        match &info.role {
+            Some(SpecRole::Axiom) => {
                 self.axiom_functions.insert(func_env.get_qualified_id());
             }
-
-            if let Some(content) = Self::validate_and_read_extra_bpl(
-                env,
-                &func_env.get_loc(),
-                func_env.module_env.get_source_path(),
-                extra_bpl,
-            ) {
-                self.function_extra_bpl
-                    .insert(func_env.get_qualified_id(), content);
-            }
-
-            if let Some(loop_inv) = loop_inv {
-                match Self::parse_module_access(&loop_inv.target, &func_env.module_env) {
-                    Some((module_name, fun_name)) => {
-                        if let Some(module_env) = env.find_module(&module_name) {
-                            self.process_loop_inv(func_env, &module_env, fun_name, loop_inv.label);
-                        } else {
-                            env.diag(
-                                Severity::Error,
-                                &func_env.get_loc(),
-                                &format!(
-                                    "loop_inv target module not found for path '{}'",
-                                    module_name.display(env.symbol_pool())
-                                ),
-                            );
-                        }
-                    }
-                    None => {
-                        let module_name = func_env.module_env.get_full_name_str();
-
-                        env.diag(
-                            Severity::Error,
-                            &func_env.get_loc(),
-                            &format!("Error parsing module path '{}'", module_name),
-                        );
-                    }
-                }
-                return;
-            }
-
-            if inv_target.is_some() {
-                match Self::parse_module_access(inv_target.as_ref().unwrap(), &func_env.module_env)
+            Some(SpecRole::LoopInvariant { target, label }) => {
+                let Some(target) = target else {
+                    env.diag(
+                        Severity::Error,
+                        &func_env.get_loc(),
+                        "`loop_inv` in #[ext(spec(...))] requires a `target` parameter",
+                    );
+                    return;
+                };
+                if let Some((module_env, fun_name)) =
+                    Self::resolve_attr_target(func_env, target, "loop_inv target")
                 {
-                    Some((module_name, struct_name)) => {
-                        if let Some(module_env) = env.find_module(&module_name) {
-                            self.process_inv(func_env, &module_env, struct_name);
-                        } else {
-                            env.diag(
-                                Severity::Error,
-                                &func_env.get_loc(),
-                                &format!(
-                                    "inv_target module not found for path '{}'",
-                                    module_name.display(env.symbol_pool())
-                                ),
-                            );
-                        }
-                    }
-                    None => {
-                        let module_name = func_env.module_env.get_full_name_str();
-
-                        env.diag(
-                            Severity::Error,
-                            &func_env.get_loc(),
-                            &format!("Error parsing module path '{}'", module_name),
-                        );
-                    }
+                    self.process_loop_inv(func_env, &module_env, fun_name, *label);
                 }
-            } else {
-                func_env
-                    .get_name_str()
-                    .strip_suffix("_inv")
-                    .map(|struct_name: &str| {
-                        self.process_inv(func_env, &func_env.module_env, struct_name.to_string());
-                    });
+            }
+            Some(SpecRole::Invariant { target }) => {
+                if let Some((module_env, struct_name)) =
+                    Self::resolve_attr_target(func_env, target, "inv_target")
+                {
+                    self.process_inv(func_env, &module_env, struct_name);
+                }
+            }
+            None => {
+                // The `type_inv` intrinsic ends in `_inv` but is not a datatype invariant.
+                if func_env.get_qualified_id() == env.type_inv_qid() {
+                    return;
+                }
+                if let Some(struct_name) = func_env.get_name_str().strip_suffix("_inv") {
+                    self.process_inv(func_env, &func_env.module_env, struct_name.to_string());
+                }
             }
         }
     }
@@ -581,51 +594,36 @@ impl PackageTargets {
     }
 
     fn check_abort_check_scope(&mut self, func_env: &FunctionEnv) {
-        if let Some(KnownAttribute::External(ExternalAttribute { attrs })) = func_env
-            .get_toplevel_attributes()
-            .get_(&AttributeKind_::External)
-            .map(|attr| &attr.value)
-        {
-            let has_no_abort = attrs
-                .into_iter()
-                .any(|attr| attr.2.value.name().value.as_str() == "no_abort");
-            let has_pure = attrs
-                .into_iter()
-                .any(|attr| attr.2.value.name().value.as_str() == "pure");
-            let has_uninterpreted = attrs
-                .into_iter()
-                .any(|attr| attr.2.value.name().value.as_str() == "uninterpreted");
-
-            if has_no_abort {
-                self.abort_check_functions
+        let flags = get_ext_flags(func_env.get_toplevel_attributes());
+        if flags.no_abort {
+            self.abort_check_functions
+                .insert(func_env.get_qualified_id());
+            if self.is_target(func_env) {
+                self.target_no_abort_check_functions
                     .insert(func_env.get_qualified_id());
-                if self.is_target(func_env) {
-                    self.target_no_abort_check_functions
-                        .insert(func_env.get_qualified_id());
-                }
             }
-            if has_pure {
-                self.pure_functions.insert(func_env.get_qualified_id());
-                if self.is_target(func_env) {
-                    self.target_no_abort_check_functions
-                        .insert(func_env.get_qualified_id());
-                }
+        }
+        if flags.pure {
+            self.pure_functions.insert(func_env.get_qualified_id());
+            if self.is_target(func_env) {
+                self.target_no_abort_check_functions
+                    .insert(func_env.get_qualified_id());
             }
-            if has_uninterpreted {
-                if !has_pure {
-                    let env = func_env.module_env.env;
-                    env.diag(
-                        Severity::Error,
-                        &func_env.get_loc(),
-                        &format!(
-                            "#[ext(uninterpreted)] on '{}' requires #[ext(pure)]",
-                            func_env.get_full_name_str(),
-                        ),
-                    );
-                } else {
-                    self.globally_uninterpreted_functions
-                        .insert(func_env.get_qualified_id());
-                }
+        }
+        if flags.uninterpreted {
+            if !flags.pure {
+                let env = func_env.module_env.env;
+                env.diag(
+                    Severity::Error,
+                    &func_env.get_loc(),
+                    &format!(
+                        "#[ext(uninterpreted)] on '{}' requires #[ext(pure)]",
+                        func_env.get_full_name_str(),
+                    ),
+                );
+            } else {
+                self.globally_uninterpreted_functions
+                    .insert(func_env.get_qualified_id());
             }
         }
     }
@@ -971,35 +969,26 @@ impl PackageTargets {
     }
 
     fn handle_module_explicit_spec_attributes(&mut self, module_env: &ModuleEnv) {
-        if let Some(KnownAttribute::Verification(VerificationAttribute::SpecOnly {
-            inv_target: _,
-            loop_inv: _,
-            axiom: _,
-            explicit_spec_modules,
-            explicit_specs,
-            extra_bpl,
-        })) = module_env
-            .get_toplevel_attributes()
-            .get_(&AttributeKind_::SpecOnly)
-            .map(|attr| &attr.value)
-        {
-            if let Some(attrs) = Self::handle_explicit_spec_attributes(
-                module_env,
-                explicit_spec_modules,
-                explicit_specs,
-            ) {
-                self.module_external_attributes
-                    .insert(module_env.get_id(), attrs);
-            }
+        let Some(info) = module_env.get_spec_info() else {
+            return;
+        };
 
-            if let Some(content) = Self::validate_and_read_extra_bpl(
-                module_env.env,
-                &module_env.get_loc(),
-                module_env.get_source_path(),
-                extra_bpl,
-            ) {
-                self.module_extra_bpl.insert(module_env.get_id(), content);
-            }
+        if let Some(attrs) = Self::handle_explicit_spec_attributes(
+            module_env,
+            &info.explicit_spec_modules,
+            &info.explicit_specs,
+        ) {
+            self.module_external_attributes
+                .insert(module_env.get_id(), attrs);
+        }
+
+        if let Some(content) = Self::validate_and_read_extra_bpl(
+            module_env.env,
+            &module_env.get_loc(),
+            module_env.get_source_path(),
+            &info.extra_bpl,
+        ) {
+            self.module_extra_bpl.insert(module_env.get_id(), content);
         }
     }
 

--- a/crates/sui-prover/src/prove.rs
+++ b/crates/sui-prover/src/prove.rs
@@ -11,6 +11,7 @@ use move_model::model::GlobalEnv;
 use move_package::{BuildConfig as MoveBuildConfig, LintFlag};
 use move_prover_boogie_backend::boogie_backend::options::BoogieFileMode;
 use move_prover_boogie_backend::generator::run_boogie_gen;
+use move_stackless_bytecode::attr_query::SPEC_MODE;
 use move_stackless_bytecode::function_stats;
 use move_stackless_bytecode::package_targets::PackageTargets;
 use move_stackless_bytecode::target_filter::TargetFilterOptions;
@@ -40,7 +41,7 @@ impl From<BuildConfig> for MoveBuildConfig {
             additional_named_addresses: config.additional_named_addresses,
             save_disassembly: false,
             implicit_dependencies: BTreeMap::new(),
-            modes: vec![ModeAttribute::VERIFY_ONLY.into()],
+            modes: vec![ModeAttribute::VERIFY_ONLY.into(), SPEC_MODE.into()],
             force_lock_file: false,
         }
     }

--- a/crates/sui-prover/tests/inputs/asserts-ignore.warn.move
+++ b/crates/sui-prover/tests/inputs/asserts-ignore.warn.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures,asserts};
 
 fun foo(a: u128): bool {

--- a/crates/sui-prover/tests/inputs/axioms/broke_fun.ok.move
+++ b/crates/sui-prover/tests/inputs/axioms/broke_fun.ok.move
@@ -2,7 +2,8 @@ module 0x42::simple_axiom;
 
 use prover::prover::ensures;
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
+#[allow(unused_function)]
 fun f_axiom(x: &u64): bool {
     (*x).to_int().sqrt() == 3u8.to_int()
 }

--- a/crates/sui-prover/tests/inputs/axioms/call.fail.move
+++ b/crates/sui-prover/tests/inputs/axioms/call.fail.move
@@ -2,7 +2,7 @@ module 0x42::simple_axiom;
 
 use prover::prover::ensures;
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
 fun f_axiom(x: u64): bool {
   x.to_int().sqrt().gte(1u8.to_int())
 }

--- a/crates/sui-prover/tests/inputs/axioms/calling_proc.fail.move
+++ b/crates/sui-prover/tests/inputs/axioms/calling_proc.fail.move
@@ -2,7 +2,8 @@ module 0x42::simple_axiom;
 
 use prover::prover::ensures;
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
+#[allow(unused_function)]
 fun f_axiom(x: u64): bool {
     bar() && x > 4 && x.to_int().sqrt().gt(2u64.to_int())
 }

--- a/crates/sui-prover/tests/inputs/axioms/calling_proc.ok.move
+++ b/crates/sui-prover/tests/inputs/axioms/calling_proc.ok.move
@@ -2,7 +2,8 @@ module 0x42::simple_axiom;
 
 use prover::prover::ensures;
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
+#[allow(unused_function)]
 fun f_axiom(x: u64): bool {
     foo() && x > 4 && x.to_int().sqrt().gt(2u64.to_int())
 }

--- a/crates/sui-prover/tests/inputs/axioms/mut_ref.fail.move
+++ b/crates/sui-prover/tests/inputs/axioms/mut_ref.fail.move
@@ -2,7 +2,8 @@ module 0x42::simple_axiom;
 
 use prover::prover::ensures;
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
+#[allow(unused_function)]
 fun f_axiom(x: &mut u64): bool {
     *x > 4 && (*x).to_int().sqrt().gt(2u64.to_int())
 }

--- a/crates/sui-prover/tests/inputs/axioms/nested_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/axioms/nested_pure.ok.move
@@ -13,7 +13,8 @@ fun sums<T>(y: &vector<T>): bool {
     sum_range(y, 0, 3).gt(5u8.to_int()) && sum_range(y, 0, 3).lt(25u8.to_int())
 }
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
+#[allow(unused_function)]
 fun f_axiom(v: &vector<u8>): bool {
     let y = filter_range!<u8>(v, 0, 3, |x| is_qualified(x));
     sums<u8>(y)

--- a/crates/sui-prover/tests/inputs/axioms/quantifier.ok.move
+++ b/crates/sui-prover/tests/inputs/axioms/quantifier.ok.move
@@ -8,7 +8,8 @@ fun is_qualified(x: &u8): bool {
     *x > 1 && *x < 20 && *x % 2 == 0
 }
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
+#[allow(unused_function)]
 fun f_axiom(v: &vector<u8>): bool {
     let y = filter_range!<u8>(v, 0, 3, |x| is_qualified(x));
     sum_range(y, 0, 3).gt(5u8.to_int()) && sum_range(y, 0, 3).lt(25u8.to_int())

--- a/crates/sui-prover/tests/inputs/axioms/returns.fail.move
+++ b/crates/sui-prover/tests/inputs/axioms/returns.fail.move
@@ -3,7 +3,8 @@ module 0x42::simple_axiom;
 use prover::prover::ensures;
 use std::integer::Integer;
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
+#[allow(unused_function)]
 fun f_axiom(x: u64): Integer {
     x.to_int().sqrt()
 }

--- a/crates/sui-prover/tests/inputs/axioms/simple.ok.move
+++ b/crates/sui-prover/tests/inputs/axioms/simple.ok.move
@@ -2,7 +2,8 @@ module 0x42::simple_axiom;
 
 use prover::prover::ensures;
 
-#[spec_only(axiom)]
+#[mode(spec), ext(spec(axiom))]
+#[allow(unused_function)]
 fun f_axiom(x: u64): bool {
     x > 4 && x.to_int().sqrt().gt(2u64.to_int())
 }

--- a/crates/sui-prover/tests/inputs/conditionals/pure_0.fail.move
+++ b/crates/sui-prover/tests/inputs/conditionals/pure_0.fail.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/conditionals/pure_0.ok.move
+++ b/crates/sui-prover/tests/inputs/conditionals/pure_0.ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/conditionals/pure_1.fail.move
+++ b/crates/sui-prover/tests/inputs/conditionals/pure_1.fail.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/conditionals/pure_1.ok.move
+++ b/crates/sui-prover/tests/inputs/conditionals/pure_1.ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/conditionals/pure_2.ok.move
+++ b/crates/sui-prover/tests/inputs/conditionals/pure_2.ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/conditionals/pure_3.ok.move
+++ b/crates/sui-prover/tests/inputs/conditionals/pure_3.ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/conditionals/pure_4.ok.move
+++ b/crates/sui-prover/tests/inputs/conditionals/pure_4.ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/conditionals/simple_max.fail.move
+++ b/crates/sui-prover/tests/inputs/conditionals/simple_max.fail.move
@@ -1,6 +1,6 @@
 module 0x42::simple_max_failure_test;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 // A broken max function that returns the minimum instead (should fail verification)

--- a/crates/sui-prover/tests/inputs/conditionals/simple_max.ok.move
+++ b/crates/sui-prover/tests/inputs/conditionals/simple_max.ok.move
@@ -1,6 +1,6 @@
 module 0x42::simple_max_succeeds_test;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/dynamic_field_ext/borrow_or_unknown.fail.move
+++ b/crates/sui-prover/tests/inputs/dynamic_field_ext/borrow_or_unknown.fail.move
@@ -3,10 +3,10 @@ module 0x42::dynamic_field_ext_borrow_or_unknown_fail;
 
 use sui::dynamic_field;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::dynamic_field::borrow_or_unknown;
 
 public struct Foo has key {

--- a/crates/sui-prover/tests/inputs/dynamic_field_ext/borrow_or_unknown.ok.move
+++ b/crates/sui-prover/tests/inputs/dynamic_field_ext/borrow_or_unknown.ok.move
@@ -3,10 +3,10 @@ module 0x42::dynamic_field_ext_borrow_or_unknown_ok;
 
 use sui::dynamic_field;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::dynamic_field::borrow_or_unknown;
 
 public struct Foo has key {

--- a/crates/sui-prover/tests/inputs/dynamic_object_field_ext/borrow_or_unknown.ok.move
+++ b/crates/sui-prover/tests/inputs/dynamic_object_field_ext/borrow_or_unknown.ok.move
@@ -3,10 +3,10 @@ module 0x42::dynamic_object_field_ext_borrow_or_unknown_ok;
 
 use sui::dynamic_object_field;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::dynamic_object_field::borrow_or_unknown;
 
 public struct Parent has key {

--- a/crates/sui-prover/tests/inputs/ext_spec_requires_mode.fail.move
+++ b/crates/sui-prover/tests/inputs/ext_spec_requires_mode.fail.move
@@ -1,0 +1,17 @@
+module 0x42::ext_spec_requires_mode_test;
+
+// #[ext(spec(...))] without #[mode(spec)] should produce an error
+#[ext(spec(axiom))]
+fun helper(): bool {
+    true
+}
+
+public fun foo(): u64 {
+    1
+}
+
+#[spec(prove)]
+public fun foo_spec(): u64 {
+    let _ = helper();
+    foo()
+}

--- a/crates/sui-prover/tests/inputs/extra_bpl/function_level.multiple.move
+++ b/crates/sui-prover/tests/inputs/extra_bpl/function_level.multiple.move
@@ -1,16 +1,16 @@
 #[allow(unused)]
-#[spec_only]
+#[mode(spec)]
 module 0x42::extra_bpl_module_test;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // Native function defined in the module-level extra BPL file
-#[spec_only]
+#[mode(spec)]
 native fun custom_multiply_1(x: u64, y: u64): u64;
 
 // Native function defined in the module-level extra BPL file
-#[spec_only]
+#[mode(spec)]
 native fun custom_multiply_2(x: u64, y: u64): u64;
 
 #[spec(prove, extra_bpl = b"m_1.ok.bpl", extra_bpl = b"m_2.ok.bpl")]

--- a/crates/sui-prover/tests/inputs/extra_bpl/invalid_extension.fail.move
+++ b/crates/sui-prover/tests/inputs/extra_bpl/invalid_extension.fail.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::extra_bpl_invalid_ext;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // This should fail because the file doesn't have .bpl extension

--- a/crates/sui-prover/tests/inputs/extra_bpl/missing_file.fail.move
+++ b/crates/sui-prover/tests/inputs/extra_bpl/missing_file.fail.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::extra_bpl_missing;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // This should fail because the file doesn't exist

--- a/crates/sui-prover/tests/inputs/extra_bpl/module_level.multiple.move
+++ b/crates/sui-prover/tests/inputs/extra_bpl/module_level.multiple.move
@@ -1,16 +1,16 @@
 #[allow(unused)]
-#[spec_only(extra_bpl = b"m_1.ok.bpl", extra_bpl = b"m_2.ok.bpl")]
+#[mode(spec), ext(spec(extra_bpl(a = b"m_1.ok.bpl", b = b"m_2.ok.bpl")))]
 module 0x42::extra_bpl_module_test;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // Native function defined in the module-level extra BPL file
-#[spec_only]
+#[mode(spec)]
 native fun custom_multiply_1(x: u64, y: u64): u64;
 
 // Native function defined in the module-level extra BPL file
-#[spec_only]
+#[mode(spec)]
 native fun custom_multiply_2(x: u64, y: u64): u64;
 
 

--- a/crates/sui-prover/tests/inputs/extra_bpl/module_level.ok.move
+++ b/crates/sui-prover/tests/inputs/extra_bpl/module_level.ok.move
@@ -1,12 +1,12 @@
 #[allow(unused)]
-#[spec_only(extra_bpl = b"module_level.ok.bpl")]
+#[mode(spec), ext(spec(extra_bpl = b"module_level.ok.bpl"))]
 module 0x42::extra_bpl_module_test;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // Native function defined in the module-level extra BPL file
-#[spec_only]
+#[mode(spec)]
 native fun custom_multiply(x: u64, y: u64): u64;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/extra_bpl/simple.ok.move
+++ b/crates/sui-prover/tests/inputs/extra_bpl/simple.ok.move
@@ -1,11 +1,11 @@
 #[allow(unused)]
 module 0x42::extra_bpl_test;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // Native function that will be defined in the extra BPL file
-#[spec_only]
+#[mode(spec)]
 native fun custom_add(x: u64, y: u64): u64;
 
 #[spec(prove, extra_bpl = b"simple.ok.bpl")]

--- a/crates/sui-prover/tests/inputs/ghost_variable_compiler_checks/nospec_declaration.move
+++ b/crates/sui-prover/tests/inputs/ghost_variable_compiler_checks/nospec_declaration.move
@@ -7,7 +7,7 @@ public fun foo<U, V>() {
     ghost::declare_global_mut<V, bool>();
 }
 
-#[spec_only]
+#[mode(spec)]
 public fun bar<T>() {
     ghost::declare_global_mut<T, bool>();
     ghost::declare_global<u64, bool>();

--- a/crates/sui-prover/tests/inputs/ints.fail.move
+++ b/crates/sui-prover/tests/inputs/ints.fail.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
 public fun foo(x: u64): u64 {

--- a/crates/sui-prover/tests/inputs/ints.ok.move
+++ b/crates/sui-prover/tests/inputs/ints.ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
 public fun foo(x: u64): u64 {

--- a/crates/sui-prover/tests/inputs/inv/datatype_invariant.move
+++ b/crates/sui-prover/tests/inputs/inv/datatype_invariant.move
@@ -73,12 +73,12 @@ public fun test_spec<T>(a: Point<T>, b: Point<T>, c: Point<T>): (Range<T>, Range
     test(a, b, c)
 }
 
-#[spec_only]
+#[mode(spec)]
 public fun Range_inv<T>(self: &Range<T>): bool {
     self.begin.x <= self.end.x && true_const()
 }
 
-#[spec_only]
+#[mode(spec)]
 fun true_const(): bool {
     true
 }

--- a/crates/sui-prover/tests/inputs/inv/inv-panic.move
+++ b/crates/sui-prover/tests/inputs/inv/inv-panic.move
@@ -10,7 +10,7 @@ public fun bar_spec(ctx: &mut TxContext): Versioned {
     bar(ctx)
 }
 
-#[spec_only]
+#[mode(spec)]
 use sui::random::RandomInner;
 
 #[spec]

--- a/crates/sui-prover/tests/inputs/inv/inv.ok.move
+++ b/crates/sui-prover/tests/inputs/inv/inv.ok.move
@@ -15,7 +15,7 @@ module 0x42::inv_foo {
         bar.set_value(150);
     }
 
-    #[spec_only]
+    #[mode(spec)]
     public fun Bar_inv(bar: &Bar): bool {
         bar.x < 150
     }

--- a/crates/sui-prover/tests/inputs/inv/inv_not_found.move
+++ b/crates/sui-prover/tests/inputs/inv/inv_not_found.move
@@ -15,7 +15,7 @@ module 0x42::inv_foo {
         bar.set_value(150);
     }
 
-    #[spec_only]
+    #[mode(spec)]
     public fun foo_inv(bar: &Bar): bool {
         bar.x < 150
     }

--- a/crates/sui-prover/tests/inputs/inv/inv_type_detection.move
+++ b/crates/sui-prover/tests/inputs/inv/inv_type_detection.move
@@ -77,7 +77,7 @@ fun initial_exchange_rate(): PoolTokenExchangeRate {
     PoolTokenExchangeRate { sui_amount: 0, pool_token_amount: 0 }
 }
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::requires;
 
 #[spec(prove, no_opaque)]
@@ -85,7 +85,7 @@ public fun is_equal_staking_metadata_spec(self: &StakedSui, other: &StakedSui): 
     is_equal_staking_metadata(self, other)
 }
 
-#[spec_only]
+#[mode(spec)]
 public fun activation_epoch_is_positive(pool: &StakingPool): bool {
     pool.activation_epoch.is_some() &&
     *pool.activation_epoch.borrow() > 0
@@ -102,7 +102,8 @@ public fun pool_token_exchange_rate_at_epoch_spec(
 }
 
 
-#[spec_only(inv_target=std::option::Option)]
+#[mode(spec), ext(spec(inv_target=std::option::Option))]
+#[allow(unused_function)]
 fun Option_inv<T>(self: &Option<T>): bool {
     if (self.is_some()) {
         let o = prover::prover::val(self.borrow());

--- a/crates/sui-prover/tests/inputs/inv/inv_type_detection_nested.move
+++ b/crates/sui-prover/tests/inputs/inv/inv_type_detection_nested.move
@@ -89,7 +89,7 @@ fun initial_exchange_rate(): PoolTokenExchangeRate {
     PoolTokenExchangeRate { sui_amount: 0, pool_token_amount: 0 }
 }
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::requires;
 
 #[spec(prove, no_opaque)]
@@ -97,7 +97,7 @@ public fun is_equal_staking_metadata_spec(self: &StakedSui, other: &StakedSui): 
     is_equal_staking_metadata(self, other)
 }
 
-#[spec_only]
+#[mode(spec)]
 public fun activation_epoch_is_positive(pw: &StakingPoolWrap): bool {
     pw.pool.activation_epoch.is_some() &&
     *pw.pool.activation_epoch.borrow() > 0
@@ -114,7 +114,8 @@ public fun pool_token_exchange_rate_at_epoch_spec(
 }
 
 
-#[spec_only(inv_target=std::option::Option)]
+#[mode(spec), ext(spec(inv_target=std::option::Option))]
+#[allow(unused_function)]
 fun Option_inv<T>(self: &Option<T>): bool {
     if (self.is_some()) {
         let o = prover::prover::val(self.borrow());

--- a/crates/sui-prover/tests/inputs/inv/issue_366.move
+++ b/crates/sui-prover/tests/inputs/inv/issue_366.move
@@ -20,7 +20,7 @@ module 0x42::b {
 module 0x42::c {
     use 0x42::b::{Sb};
 
-    #[spec_only(inv_target=Sb)]
+    #[mode(spec), ext(spec(inv_target=Sb))]
     public fun Sb_inv(self: &Sb): bool {
         self.x().is_in_good_state()
     }

--- a/crates/sui-prover/tests/inputs/inv/recursive_type_inv.move
+++ b/crates/sui-prover/tests/inputs/inv/recursive_type_inv.move
@@ -7,7 +7,8 @@ public struct Leaf has copy, drop, store {
     right: Option<Leaf>,
 }
 
-#[spec_only(inv_target=0x42::recursive_type_inv::Leaf)]
+#[mode(spec), ext(spec(inv_target=0x42::recursive_type_inv::Leaf))]
+#[allow(unused_function)]
 fun Leaf_inv(self: &Leaf): bool {
     self.value > 0
 }
@@ -39,7 +40,8 @@ public fun new_c(value: u64): C {
     C { value, a_field: vector[] }
 }
 
-#[spec_only(inv_target=0x42::recursive_type_inv::A)]
+#[mode(spec), ext(spec(inv_target=0x42::recursive_type_inv::A))]
+#[allow(unused_function)]
 fun A_inv(self: &A): bool {
     self.value > 0
 }

--- a/crates/sui-prover/tests/inputs/inv_paths/duplicate_target.move
+++ b/crates/sui-prover/tests/inputs/inv_paths/duplicate_target.move
@@ -17,15 +17,17 @@ module 0x42::inv_path_foo {
 }
 
 module 0x43::inv_path_foo_spec {
-    #[spec_only]
+    #[mode(spec)]
     use 0x42::inv_path_foo::{increment, Bar};
 
-    #[spec_only(inv_target = 0x42::inv_path_foo::Bar)]
+    #[mode(spec), ext(spec(inv_target = 0x42::inv_path_foo::Bar))]
+    #[allow(unused_function)]
     fun foo(bar: &Bar): bool {
         bar.get_values() < 150
     }
 
-    #[spec_only(inv_target = 0x42::inv_path_foo::Bar)]
+    #[mode(spec), ext(spec(inv_target = 0x42::inv_path_foo::Bar))]
+    #[allow(unused_function)]
     fun foobar(bar: &Bar): bool {
         bar.get_values() < 250
     }

--- a/crates/sui-prover/tests/inputs/inv_paths/inv_path.ok.move
+++ b/crates/sui-prover/tests/inputs/inv_paths/inv_path.ok.move
@@ -17,10 +17,11 @@ module 0x42::inv_path_foo {
 }
 
 module 0x43::inv_path_foo_spec {
-    #[spec_only]
+    #[mode(spec)]
     use 0x42::inv_path_foo::{increment, Bar};
 
-    #[spec_only(inv_target = 0x42::inv_path_foo::Bar)]
+    #[mode(spec), ext(spec(inv_target = 0x42::inv_path_foo::Bar))]
+    #[allow(unused_function)]
     fun foo(bar: &Bar): bool {
         bar.get_values() < 150
     }

--- a/crates/sui-prover/tests/inputs/inv_paths/struct_not_found.move
+++ b/crates/sui-prover/tests/inputs/inv_paths/struct_not_found.move
@@ -17,10 +17,11 @@ module 0x42::inv_path_foo {
 }
 
 module 0x43::inv_path_foo_spec {
-    #[spec_only]
+    #[mode(spec)]
     use 0x42::inv_path_foo::{increment, Bar};
 
-    #[spec_only(inv_target = 0x42::inv_path_foo::Baz)]
+    #[mode(spec), ext(spec(inv_target = 0x42::inv_path_foo::Baz))]
+    #[allow(unused_function)]
     fun foo(bar: &Bar): bool {
         bar.get_values() < 150
     }

--- a/crates/sui-prover/tests/inputs/issue-102.move
+++ b/crates/sui-prover/tests/inputs/issue-102.move
@@ -2,7 +2,7 @@ module 0x42::issue_102;
 
 use prover::prover::{ensures, requires, invariant};
 
-#[spec_only]
+#[mode(spec)]
 fun fib(n: u16): u16 {
     if (n <= 1) {
         1

--- a/crates/sui-prover/tests/inputs/issue-145.move
+++ b/crates/sui-prover/tests/inputs/issue-145.move
@@ -10,7 +10,7 @@ public fun bar_spec(ctx: &mut TxContext): Versioned {
     bar(ctx)
 }
 
-#[spec_only]
+#[mode(spec)]
 use sui::random::RandomInner;
 
 #[spec]

--- a/crates/sui-prover/tests/inputs/issue-299.move
+++ b/crates/sui-prover/tests/inputs/issue-299.move
@@ -18,7 +18,8 @@ module 0x42::B {
     use std::option::some;
     use prover::prover::{val, drop};
 
-    #[spec_only(inv_target=std::option::Option)]
+    #[mode(spec), ext(spec(inv_target=std::option::Option))]
+    #[allow(unused_function)]
     fun Option_inv<T>(self: &Option<T>): bool {
         if (self.is_some()) {
             let o = val(self.borrow());

--- a/crates/sui-prover/tests/inputs/issue-362.move
+++ b/crates/sui-prover/tests/inputs/issue-362.move
@@ -8,7 +8,8 @@ module 0x42::A {
         (*x)%2 == 1
     }
 
-    #[spec_only(loop_inv(target=0x42::foo::find_odd_index2)), ext(pure)]
+    #[mode(spec), ext(spec(loop_inv(target=0x42::foo::find_odd_index2)), pure)]
+    #[allow(unused_function)]
     fun foo_inv(v: &vector<u64>, i: u64): bool {
         i <= v.length() && !any_range!(v, 0, i, |x| is_odd(x))
     }

--- a/crates/sui-prover/tests/inputs/logging.move
+++ b/crates/sui-prover/tests/inputs/logging.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
 public fun foo(x: u64): u64 {

--- a/crates/sui-prover/tests/inputs/loop_invariant/base_case_fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/base_case_fail.move
@@ -4,7 +4,8 @@ module 0x42::base_case_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = foo_spec)), ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = foo_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_0(i: u64, n: u64): bool {
     // This invariant is wrong at entry: i starts at 0, but we claim i > 0.
     i > 0 && i <= n

--- a/crates/sui-prover/tests/inputs/loop_invariant/external.ok.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external.ok.move
@@ -4,38 +4,38 @@ use prover::prover::{requires, ensures, clone};
 use prover::ghost;
 use std::integer::Integer;
 
-#[spec_only(loop_inv(target = test0_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test0_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_0(i: u64, n: u64): bool {
     i <= n
 }
 
-#[spec_only(loop_inv(target = test1_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test1_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_1(i: u64, n: u64, s: u128): bool {
     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }
 
-#[spec_only(loop_inv(target = test2_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test2_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_2(i: u64, n: u64, s: u128): bool {
     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }
 
-#[spec_only(loop_inv(target = test3_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test3_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_3(n: u64, old_n: u64, s: u128): bool {
     n <= old_n && (s == ((old_n as u128) - (n as u128)) * ((old_n as u128) + (n as u128) + 1) / 2)
 }
 
-#[spec_only(loop_inv(target = test4_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test4_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_4(i: u64, n: u64, s: u128): bool {
     i < n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }
 
-#[spec_only(loop_inv(target = test6_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test6_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_6(i: u64, n: u64, old_s: u128, ss: u128): bool {
     i <= n && ((ss as u256) == (old_s as u256) + (i as u256) * ((i as u256) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_aborts.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_aborts.fail.move
@@ -2,7 +2,8 @@ module 0x42::loop_invariant_external_aborts_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)))]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, s: u128): bool {
     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_arg_names.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_arg_names.move
@@ -1,6 +1,7 @@
 module 0x42::loop_invariant_external_aborts_fail;
 
-#[spec_only(loop_inv(target=bar)), ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target=bar)), no_abort)]
+#[allow(unused_function)]
 fun bar_loop_inv(i: u64, stop: u64, v__3: &vector<u8>): bool {
     i <= stop && v__3.length() == stop - i
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_bool_with_ensures.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_bool_with_ensures.fail.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_bool_with_ensures_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64): bool {
     ensures(i <= n);
     i <= n

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_clone.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_clone.fail.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_clone;
 
 use prover::prover::{ensures, clone};
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(pure)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), pure)]
+#[allow(unused_function)]
 fun loop_inv(n: u64, __old_n: u64, __old_p: u64, s: u128): bool { // Wrong naming for old variable
     n <= __old_n && (s == ((__old_n as u128) - (n as u128)) * ((__old_n as u128) + (n as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_clone.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_clone.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_clone;
 
 use prover::prover::{ensures, clone};
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(pure)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), pure)]
+#[allow(unused_function)]
 fun loop_inv(n: u64, __old_n: u64, s: u128): bool {
     n <= __old_n && (s == ((__old_n as u128) - (n as u128)) * ((__old_n as u128) + (n as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_clone_mut.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_clone_mut.move
@@ -15,7 +15,7 @@ public fun foo(s: &mut Foo) {
     }
 }
 
-#[spec_only(loop_inv(target = foo)), ext(pure)]
+#[mode(spec), ext(spec(loop_inv(target = foo)), pure)]
 public fun foo_inv(s: &Foo, i: u64, __old_s: &Foo): bool {
     i <= s.y &&
     s.x.to_int() == __old_s.x.to_int().add(i.to_int()) &&

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_inv_aborts.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_inv_aborts.fail.move
@@ -2,7 +2,8 @@ module 0x42::loop_invariant_external_inv_aborts_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)))]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, s: u128): bool {
     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_invalid_arg_name.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_invalid_arg_name.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_invalid_arg_name_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, compare: u128): bool {
     i <= n && (compare == (i as u128) * ((i as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_invalid_arg_name_macro.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_invalid_arg_name_macro.move
@@ -28,8 +28,8 @@ macro fun test_loop_2($n: u64): u128 {
     s
 }
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, compare: u128): bool {
     i <= n && (compare == (i as u128) * ((i as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_multi_module.ok.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_multi_module.ok.move
@@ -1,9 +1,8 @@
 // Two modules provide a loop invariant for the same spec function.
 // The invariant in the same module as the spec should be selected.
 module 0x42::other_specs {
-    #[allow(unused_variable)]
-    #[spec_only(loop_inv(target = 0x42::my_specs::test_spec))]
-    #[ext(no_abort)]
+    #[allow(unused_variable, unused_function)]
+    #[mode(spec), ext(spec(loop_inv(target = 0x42::my_specs::test_spec)), no_abort)]
     fun loop_inv_other(i: u64, n: u64): bool {
         // This invariant is intentionally too weak; it would fail if selected.
         true
@@ -13,8 +12,8 @@ module 0x42::other_specs {
 module 0x42::my_specs {
     use prover::prover::ensures;
 
-    #[spec_only(loop_inv(target = test_spec))]
-    #[ext(no_abort)]
+    #[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+    #[allow(unused_function)]
     fun loop_inv(i: u64, n: u64): bool {
         i <= n
     }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_mut_ref.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_mut_ref.fail.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_mut_ref_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused)]
 fun loop_inv(i: u64, n: u64, s: &mut u128): bool {
     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_mut_ref.ok.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_mut_ref.ok.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_mut_ref_ok;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, p: &u128): bool {
     i <= n && (*p == (i as u128) * ((i as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_no_target.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_no_target.fail.move
@@ -2,7 +2,7 @@ module 0x42::loop_invariant_external_no_target_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(label = 0))]
+#[mode(spec), ext(spec(loop_inv(label = 0)))]
 fun loop_inv(i: u64, n: u64, s: u128): bool {
     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_return_type.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_return_type.fail.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_return_type_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused)]
 fun loop_inv(i: u64, n: u64, s: u128): u64 {
     //(i <= n, (s == (i as u128) * ((i as u128) + 1) / 2))
     n

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_returns.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_returns.fail.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_returns_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, s: u128): (bool, bool) {
     (i <= n, (s == (i as u128) * ((i as u128) + 1) / 2))
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_type_mismatch.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_type_mismatch.fail.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_type_mismatch_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, s: &u256): bool {
     i <= n && (s == (i as u256) * ((i as u256) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_void.ok.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_void.ok.move
@@ -2,35 +2,35 @@ module 0x42::loop_invariant_external_void_ok;
 
 use prover::prover::{requires, ensures, clone};
 
-#[spec_only(loop_inv(target = test0_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test0_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_0(i: u64, n: u64) {
     ensures(i <= n);
 }
 
-#[spec_only(loop_inv(target = test1_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test1_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_1(i: u64, n: u64, s: u128) {
     ensures(i <= n);
     ensures(s == (i as u128) * ((i as u128) + 1) / 2);
 }
 
-#[spec_only(loop_inv(target = test2_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test2_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_2(n: u64, old_n: u64, s: u128) {
     ensures(n <= old_n);
     ensures(s == ((old_n as u128) - (n as u128)) * ((old_n as u128) + (n as u128) + 1) / 2);
 }
 
-#[spec_only(loop_inv(target = test3_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test3_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_3(i: u64, n: u64, s: u128) {
     ensures(i < n);
     ensures(s == (i as u128) * ((i as u128) + 1) / 2);
 }
 
-#[spec_only(loop_inv(target = test4_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test4_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_4(i: u64, n: u64, p: &u128) {
     ensures(i <= n);
     ensures(*p == (i as u128) * ((i as u128) + 1) / 2);

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_void_invalid_arg_name.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_void_invalid_arg_name.fail.move
@@ -5,8 +5,8 @@ module 0x42::loop_invariant_external_void_invalid_arg_name_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, compare: u128) {
     ensures(i <= n);
     ensures(compare == (i as u128) * ((i as u128) + 1) / 2);

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_void_with_requires.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_void_with_requires.fail.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_void_with_requires_fail;
 
 use prover::prover::{requires, ensures};
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64) {
     requires(i <= n);
     ensures(i <= n);

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_void_wrong.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_void_wrong.fail.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_void_wrong_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, s: u128) {
     ensures(i <= n);
     ensures(s == (i as u128));  // Wrong invariant

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_wrong_label.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_wrong_label.fail.move
@@ -2,8 +2,8 @@ module 0x42::loop_invariant_external_wrong_label_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec, label = 5))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec, label = 5)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv(i: u64, n: u64, s: u128): bool {
     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/external_wrong_label_2.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/external_wrong_label_2.fail.move
@@ -2,14 +2,14 @@ module 0x42::loop_invariant_external_wrong_label_2_fail;
 
 use prover::prover::ensures;
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_1(i: u64, n: u64, s: u128): bool {
     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }
 
-#[spec_only(loop_inv(target = test_spec))]
-#[ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = test_spec)), no_abort)]
+#[allow(unused_function)]
 fun loop_inv_2(i: u64, n: u64, s: u128): bool {
     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/issue-416.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/issue-416.move
@@ -8,7 +8,8 @@ fun flip(x: &u8): u8 {
     255-*x
 }
 
-#[spec_only(loop_inv(target=bar)), ext(pure)]
+#[mode(spec), ext(spec(loop_inv(target=bar)), pure)]
+#[allow(unused_function)]
 fun bar_loop_inv(i: u64, stop: u64, v__3: &vector<u8>, v: &vector<u8>, r: &vector<u8>): bool {
     i <= stop && v__3.length() == stop - i && r == map_range!(v, 0, i, |x| flip(x))
         && !exists!(|j| more_loop_inv_3(*j, v, v__3))

--- a/crates/sui-prover/tests/inputs/loop_invariant/issue-448.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/issue-448.move
@@ -11,12 +11,14 @@ public fun few(x: u8, z: u8) {
     }
 }
 
-#[spec_only(loop_inv(target = few, label = 0)), ext(pure)]
+#[mode(spec), ext(spec(loop_inv(target = few, label = 0)), pure)]
+#[allow(unused_function)]
 fun inv1(y: u8, x: u8): bool {
     y <= x
 }
 
-#[spec_only(loop_inv(target = few, label = 1)), ext(pure)]
+#[mode(spec), ext(spec(loop_inv(target = few, label = 1)), pure)]
+#[allow(unused_function)]
 fun inv2(i: u8, z: u8): bool {
     i <= z
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/issue-466.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/issue-466.move
@@ -17,7 +17,8 @@ fun f2(t: &mut T): u64 {
     t.x.length()
 }
 
-#[spec_only(loop_inv(target = f2)), ext(pure)]
+#[mode(spec), ext(spec(loop_inv(target = f2)), pure)]
+#[allow(unused_function)]
 fun f2_invariant(i: u64, length: u64, t: &T, __old_t: &T): bool {
     t.x == __old_t.x
 }

--- a/crates/sui-prover/tests/inputs/loop_invariant/map_ref_struct.ok.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/map_ref_struct.ok.move
@@ -30,7 +30,8 @@ public fun active_ids(set: &MySet): vector<u64> {
     r
 }
 
-#[spec_only(loop_inv(target = active_ids)), ext(pure)]
+#[mode(spec), ext(spec(loop_inv(target = active_ids)), pure)]
+#[allow(unused_function)]
 fun active_ids_invariant(i: u64, len: u64, set: &MySet, r: &vector<u64>): bool {
        i <= len
     && len == set.validators.length()

--- a/crates/sui-prover/tests/inputs/loop_invariant/pure_callee_with_loop_inv.fail.move
+++ b/crates/sui-prover/tests/inputs/loop_invariant/pure_callee_with_loop_inv.fail.move
@@ -30,7 +30,7 @@ public fun active_ids(set: &MySet): vector<u64> {
     r
 }
 
-#[spec_only(loop_inv(target = active_ids)), ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target = active_ids)), no_abort)]
 fun active_ids_invariant(i: u64, len: u64, set: &MySet, r: &vector<u64>): bool {
        i <= len
     && len == set.validators.length()

--- a/crates/sui-prover/tests/inputs/multiple_specs/double_context_1.fail.move
+++ b/crates/sui-prover/tests/inputs/multiple_specs/double_context_1.fail.move
@@ -20,7 +20,7 @@ module 0x42::foo_specs {
   }
 }
 
-#[spec_only(include = 0x42::foo_specs)]
+#[mode(spec), ext(spec(include = 0x42::foo_specs))]
 module 0x42::bar_specs_double_foo_imported_module {
   use prover::prover::ensures;
   use 0x42::fb::{foo, bar};

--- a/crates/sui-prover/tests/inputs/multiple_specs/double_context_2.fail.move
+++ b/crates/sui-prover/tests/inputs/multiple_specs/double_context_2.fail.move
@@ -20,7 +20,7 @@ module 0x42::foo_specs {
   }
 }
 
-#[spec_only(include = 0x42::foo_specs::foo_spec)]
+#[mode(spec), ext(spec(include = 0x42::foo_specs::foo_spec))]
 module 0x42::bar_specs_double_foo_imported_module {
   use prover::prover::ensures;
   use 0x42::fb::{foo, bar};

--- a/crates/sui-prover/tests/inputs/multiple_specs/include_external.ok.move
+++ b/crates/sui-prover/tests/inputs/multiple_specs/include_external.ok.move
@@ -18,7 +18,7 @@ module 0x42::foo_specs {
   }
 }
 
-#[spec_only(include = 0x42::foo_specs::foo_spec)]
+#[mode(spec), ext(spec(include = 0x42::foo_specs::foo_spec))]
 module 0x42::bar_specs_double_foo_imported_module {
   use prover::prover::ensures;
   use 0x42::fb::bar;

--- a/crates/sui-prover/tests/inputs/multiple_specs/multiple_external.ok.move
+++ b/crates/sui-prover/tests/inputs/multiple_specs/multiple_external.ok.move
@@ -32,7 +32,7 @@ module 0x42::bar_specs {
   }
 }
 
-#[spec_only(include = 0x42::foo_specs, include = 0x42::bar_specs)]
+#[mode(spec), ext(spec(include(a = 0x42::foo_specs, b = 0x42::bar_specs)))]
 module 0x42::foobar_specs_1 {
   use prover::prover::ensures;
   use 0x42::fb::foobar;
@@ -44,7 +44,7 @@ module 0x42::foobar_specs_1 {
   }
 }
 
-#[spec_only(include = 0x42::foo_specs::foo_spec, include = 0x42::bar_specs::bar_spec)]
+#[mode(spec), ext(spec(include(a = 0x42::foo_specs::foo_spec, b = 0x42::bar_specs::bar_spec)))]
 module 0x42::foobar_specs_2 {
   use prover::prover::ensures;
   use 0x42::fb::foobar;

--- a/crates/sui-prover/tests/inputs/multiple_specs/override_system.ok.move
+++ b/crates/sui-prover/tests/inputs/multiple_specs/override_system.ok.move
@@ -1,9 +1,9 @@
 module 0x42::foo_specs;
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
-#[spec_only]
+#[mode(spec)]
 use prover::ghost;
-#[spec_only]
+#[mode(spec)]
 use sui::transfer::{transfer, transfer_impl};
 
 public struct Foo has key {

--- a/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_complex.move
+++ b/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_complex.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 public enum Color has drop, copy {

--- a/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_fail.move
+++ b/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_fail.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 public enum Color has drop, copy {

--- a/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_nested_enum_in_enum.move
+++ b/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_nested_enum_in_enum.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 public enum ColorTypeNested has drop, copy {

--- a/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_nested_enum_in_struct.move
+++ b/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_nested_enum_in_struct.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 public enum ColorType has drop, copy {

--- a/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_nested_struct_in_enum.move
+++ b/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_nested_struct_in_enum.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 public enum Color has drop, copy {

--- a/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_simple.move
+++ b/crates/sui-prover/tests/inputs/mut_ref_enum/mut_ref_enum_simple.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 public enum Color has drop, copy {

--- a/crates/sui-prover/tests/inputs/object_table_ext/add_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/object_table_ext/add_pure.ok.move
@@ -3,10 +3,10 @@ module 0x42::object_table_ext_add_pure_ok;
 
 use sui::object_table::ObjectTable;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use sui::object_table::add_pure;
 
 public struct Foo has key, store {

--- a/crates/sui-prover/tests/inputs/object_table_ext/borrow_or_unknown.ok.move
+++ b/crates/sui-prover/tests/inputs/object_table_ext/borrow_or_unknown.ok.move
@@ -3,10 +3,10 @@ module 0x42::object_table_ext_borrow_or_unknown_ok;
 
 use sui::object_table::ObjectTable;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::object_table::borrow_or_unknown;
 
 public struct Foo has key, store {

--- a/crates/sui-prover/tests/inputs/object_table_ext/remove_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/object_table_ext/remove_pure.ok.move
@@ -3,10 +3,10 @@ module 0x42::object_table_ext_remove_pure_ok;
 
 use sui::object_table::ObjectTable;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use sui::object_table::remove_pure;
 
 public struct Foo has key, store {

--- a/crates/sui-prover/tests/inputs/omit_opaque/omit_opaque_default.move
+++ b/crates/sui-prover/tests/inputs/omit_opaque/omit_opaque_default.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 fun foo(x: &mut u8) {

--- a/crates/sui-prover/tests/inputs/omit_opaque/omit_opaque_ok.move
+++ b/crates/sui-prover/tests/inputs/omit_opaque/omit_opaque_ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures};
 
 fun foo(x: &mut u8) {

--- a/crates/sui-prover/tests/inputs/one-assert.fail.move
+++ b/crates/sui-prover/tests/inputs/one-assert.fail.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo() {

--- a/crates/sui-prover/tests/inputs/one-assert.ok.move
+++ b/crates/sui-prover/tests/inputs/one-assert.ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo() {

--- a/crates/sui-prover/tests/inputs/opaque/fresh.move
+++ b/crates/sui-prover/tests/inputs/opaque/fresh.move
@@ -2,7 +2,7 @@ module 0x42::opaque_tests;
 
 use prover::prover::{fresh};
 
-#[spec_only]
+#[mode(spec)]
 fun fresh_with_type_withness<T, U>(_: &T): U {
     fresh()
 }

--- a/crates/sui-prover/tests/inputs/print-ghost.move
+++ b/crates/sui-prover/tests/inputs/print-ghost.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 use prover::log;
 use prover::ghost;

--- a/crates/sui-prover/tests/inputs/pure_functions/multiple_returns.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/multiple_returns.ok.move
@@ -5,7 +5,7 @@
 /// Expected: Should pass verification.
 module 0x42::pure_multiple_returns;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // Pure function with 2 return values

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_callee_ok.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_callee_ok.ok.move
@@ -2,7 +2,7 @@
 /// The helper function is NOT marked #[ext(pure)] but satisfies all pure requirements.
 module 0x42::pure_callee_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // This function is NOT marked #[ext(pure)] but satisfies pure requirements:

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_conditional_smt.fail.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_conditional_smt.fail.move
@@ -6,7 +6,7 @@
 /// Expected: Should reach SMT verification and fail there (not at bytecode transformation).
 module 0x42::pure_conditional_smt;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
 // BUGGY pure function - has x - 10 instead of x - 1

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_conditional_smt.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_conditional_smt.ok.move
@@ -5,7 +5,7 @@
 /// Expected: Should reach SMT verification and pass.
 module 0x42::pure_conditional_smt_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // Valid pure function with conditional - passes all syntactic checks:

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_early_return.fail.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_early_return.fail.move
@@ -2,7 +2,7 @@
 /// This spec makes a FALSE claim to verify the early return is not dropped.
 module 0x42::pure_early_return_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_early_return.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_early_return.ok.move
@@ -2,7 +2,7 @@
 /// The early return should not be dropped during pure function translation.
 module 0x42::pure_early_return;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_early_return_nested.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_early_return_nested.ok.move
@@ -3,7 +3,7 @@
 /// should fall through to the default return value.
 module 0x42::pure_early_return_nested;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_early_return_sequential.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_early_return_sequential.ok.move
@@ -2,7 +2,7 @@
 /// Each condition is checked in order; the first match returns.
 module 0x42::pure_early_return_sequential;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_enum_match_multi_ok.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_enum_match_multi_ok.ok.move
@@ -1,6 +1,6 @@
 module 0x42::pure_enum_match_multi;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public enum Tag has copy, drop {

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_enum_match_ok.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_enum_match_ok.ok.move
@@ -1,6 +1,6 @@
 module 0x42::pure_enum_match;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public enum E has copy, drop {

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_enum_pack_ok.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_enum_pack_ok.ok.move
@@ -1,6 +1,6 @@
 module 0x42::pure_enum_pack;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, exists};
 
 public enum E has copy, drop {

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_enum_reordered_ok.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_enum_reordered_ok.ok.move
@@ -1,6 +1,6 @@
 module 0x42::pure_enum_reordered;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public enum Op has copy, drop {

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_enum_unpack_ok.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_enum_unpack_ok.ok.move
@@ -1,6 +1,6 @@
 module 0x42::pure_enum_unpack;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
 public enum Pair has copy, drop {

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_enum_wildcard_ok.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_enum_wildcard_ok.ok.move
@@ -1,6 +1,6 @@
 module 0x42::pure_enum_wildcard;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public enum Color has copy, drop {

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_forall_trailing_binder.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_forall_trailing_binder.ok.move
@@ -6,7 +6,7 @@
 /// the predicate's trailing `int` parameter and Boogie rejected it.
 module 0x42::pure_forall_trailing_binder;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, forall};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_single_field_unpack.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_single_field_unpack.ok.move
@@ -1,6 +1,6 @@
 module 0x42::pure_single_field_unpack;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{requires, val};
 
 public struct S(u8) has copy, drop;

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_smt_verification.fail.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_smt_verification.fail.move
@@ -5,7 +5,7 @@
 /// Expected: Should reach SMT verification and fail there (not at bytecode transformation).
 module 0x42::pure_smt_verification;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // Valid pure function - passes all syntactic checks:

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_tuple_return_callee.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_tuple_return_callee.ok.move
@@ -4,7 +4,7 @@
 /// on any `Call` with `dests.len() > 1`.
 module 0x42::pure_tuple_return_callee;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // --- Tuple return -----------------------------------------------------------

--- a/crates/sui-prover/tests/inputs/pure_functions/pure_xor_ok.ok.move
+++ b/crates/sui-prover/tests/inputs/pure_functions/pure_xor_ok.ok.move
@@ -3,7 +3,7 @@
 /// Mirrors integer-mate's u32_neg pattern (v ^ 0xffffffff for bitwise NOT).
 module 0x42::pure_xor_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/all_macro_loop.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/all_macro_loop.ok.move
@@ -10,7 +10,8 @@ fun is_small(x: &u64): bool {
     *x <= 256
 }
 
-#[spec_only(loop_inv(target=all_small)), ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target=all_small)), no_abort)]
+#[allow(unused_function)]
 fun all_small_invariant(v: &vector<u64>, i: u64): bool {
     all_range!(v, 0, i, |j| is_small(j))
 }

--- a/crates/sui-prover/tests/inputs/quantifiers/any_all.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/any_all.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_any_all_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{any, all};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/any_all_range.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/any_all_range.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_any_all_range_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{any_range, all_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/any_all_range.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/any_all_range.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_any_all_range_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{any_range, all_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/any_macro_loop.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/any_macro_loop.ok.move
@@ -10,7 +10,8 @@ fun is_small(x: &u64): bool {
     *x <= 256
 }
 
-#[spec_only(loop_inv(target=any_small)), ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target=any_small)), no_abort)]
+#[allow(unused_function)]
 fun any_small_invariant(v: &vector<u64>, i: u64): bool {
     ! any_range!(v, 0, i, |j| is_small(j))
 }

--- a/crates/sui-prover/tests/inputs/quantifiers/complex_usage.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/complex_usage.fail.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::quantifiers_complex_usage;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{exists, ensures, invariant};
 use prover::vector_iter::map;
 

--- a/crates/sui-prover/tests/inputs/quantifiers/complex_usage.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/complex_usage.ok.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::quantifiers_complex_usage;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{exists, ensures, requires, invariant};
 use prover::vector_iter::map;
 

--- a/crates/sui-prover/tests/inputs/quantifiers/concat.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/concat.ok.move
@@ -5,12 +5,12 @@
 #[allow(unused)]
 module 0x42::quantifiers_concat_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, invariant};
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::slice;
-#[spec_only]
+#[mode(spec)]
 use std::vector::append_pure;
 
 // Concrete values: concat of two literal vectors.

--- a/crates/sui-prover/tests/inputs/quantifiers/count.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/count.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_count_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{count, count_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/count.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/count.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_count_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{count, count_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/count_big.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/count_big.ok.move
@@ -4,10 +4,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_count_big_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::count;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/count_macro_loop.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/count_macro_loop.ok.move
@@ -10,7 +10,8 @@ fun is_small(x: &u64): bool {
     *x <= 256
 }
 
-#[spec_only(loop_inv(target=count_small)), ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target=count_small)), no_abort)]
+#[allow(unused_function)]
 fun count_small_invariant(v__3: &vector<u64>, i: u64, count: u64): bool {
     i <= v__3.length() && count <= i && count == count_range!(v__3, 0, i, |j| is_small(j))
 }

--- a/crates/sui-prover/tests/inputs/quantifiers/count_split.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/count_split.ok.move
@@ -6,10 +6,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_count_split_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{count, count_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/filter.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/filter.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_filter_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::filter;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/filter.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/filter.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_filter_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{filter, filter_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/filter_big.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/filter_big.ok.move
@@ -3,10 +3,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_filter_big_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::filter;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/find_find_index.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/find_find_index.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_find_find_index_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{find, find_index};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/find_find_index.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/find_find_index.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_find_find_index_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{find, find_index};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/find_find_index_range.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/find_find_index_range.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_find_find_index_range_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{find_range, find_index_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/find_find_index_range.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/find_find_index_range.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_find_find_index_range_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{find_range, find_index_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/find_index_macro_loop.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/find_index_macro_loop.ok.move
@@ -10,7 +10,8 @@ fun is_small(x: &u64): bool {
     *x <= 256
 }
 
-#[spec_only(loop_inv(target=find_index_small)), ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target=find_index_small)), no_abort)]
+#[allow(unused_function)]
 fun find_index_small_invariant(v: &vector<u64>, i: u64): bool {
     i <= v.length() && !any_range!(v, 0, i, |j| is_small(j))
 }

--- a/crates/sui-prover/tests/inputs/quantifiers/find_indices.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/find_indices.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_find_indices_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::find_indices;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/find_indices.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/find_indices.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_find_indices_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{find_indices, find_indices_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/find_indices_big.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/find_indices_big.ok.move
@@ -12,10 +12,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_find_indices_big_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::find_indices;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/forall_exists.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/forall_exists.ok.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::quantifiers_forall_exists_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{forall, exists, ensures};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/funs_aborts.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/funs_aborts.fail.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::quantifiers_funs_aborts_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{exists, ensures};
 
 

--- a/crates/sui-prover/tests/inputs/quantifiers/funs_non_deterministic.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/funs_non_deterministic.fail.move
@@ -1,13 +1,13 @@
 #[allow(unused)]
 module 0x42::quantifiers_funs_non_deterministic_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{forall, ensures};
 
-#[spec_only]
+#[mode(spec)]
 use sui::random::{Random, new_generator, generate_u8_in_range};
 
-#[spec_only, ext(pure)]
+#[mode(spec), ext(pure)]
 fun x_is_gte_0_non_deterministic(x: &u8, r: &Random, ctx: &mut TxContext): bool {
     let mut generator = new_generator(r, ctx); // non-deterministic
     let dice_value = generate_u8_in_range(&mut generator, 1, 6);

--- a/crates/sui-prover/tests/inputs/quantifiers/internal_var_usage_fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/internal_var_usage_fail.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::quantifiers_complex_usage;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{exists, ensures, requires, invariant};
 use prover::vector_iter::map;
 

--- a/crates/sui-prover/tests/inputs/quantifiers/issue_329.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/issue_329.move
@@ -1,9 +1,9 @@
 #[allow(unused)]
 module 0x42::issue_329;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::requires;
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{all, any};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/issue_376.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/issue_376.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_map_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures,requires};
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{map_range, map};
 
 public struct S {}

--- a/crates/sui-prover/tests/inputs/quantifiers/issue_435.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/issue_435.move
@@ -6,7 +6,7 @@ public struct Queue<T: store> has store {
     tail: u64,
 }
 
-#[spec_only, ext(pure)]
+#[mode(spec), ext(pure)]
 fun queue_borrow_or_default(queue: &Queue<u64>, i: u64): u64 {
     if (i < queue.contents.length()) {
         queue.contents[i]
@@ -15,12 +15,13 @@ fun queue_borrow_or_default(queue: &Queue<u64>, i: u64): u64 {
     }
 }
 
-#[spec_only, ext(pure)]
+#[mode(spec), ext(pure)]
 fun queue_as_vector(queue: &Queue<u64>): &vector<u64> {
     prover::vector_iter::range_map!(queue.head, queue.tail, |i| queue_borrow_or_default(queue, i))
 }
 
-#[spec_only, ext(pure)]
+#[mode(spec), ext(pure)]
+#[allow(unused_function)]
 fun foo_spec(queue: &Queue<u64>): &vector<u64> {
     queue_as_vector(queue)
 }

--- a/crates/sui-prover/tests/inputs/quantifiers/issue_436.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/issue_436.move
@@ -6,10 +6,11 @@ public struct Queue<T: copy + drop + store> has store {
     tail: u64,
 }
 
-#[spec_only, ext(pure)]
+#[mode(spec), ext(pure)]
 native fun as_vector<T: copy + drop + store>(queue: &Queue<T>): &vector<T>;
 
-#[spec_only, ext(axiom)]
+#[mode(spec), ext(axiom)]
+#[allow(unused_function)]
 fun as_vector_definition<T: copy + drop + store>(queue: &Queue<T>, i: u64): bool {
     queue.head <= queue.contents.length() &&
     queue.tail <= queue.contents.length() &&
@@ -22,7 +23,7 @@ fun as_vector_definition<T: copy + drop + store>(queue: &Queue<T>, i: u64): bool
     }
 }
 
-#[spec_only, ext(pure)]
+#[mode(spec), ext(pure)]
 fun foo(queue: &Queue<u64>): &vector<u64> {
     as_vector(queue)
 }

--- a/crates/sui-prover/tests/inputs/quantifiers/issue_439.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/issue_439.move
@@ -1,15 +1,15 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::requires;
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::filter;
 
 public struct Foo {
     x: u64,
 }
 
-#[spec_only, ext(pure)]
+#[mode(spec), ext(pure)]
 fun foo_property(
     v1: &vector<Foo>,
     v2: &vector<Foo>,
@@ -18,7 +18,7 @@ fun foo_property(
     v1 == filter!(v2, |foo| is_x(foo, x))
 }
 
-#[spec_only, ext(pure)]
+#[mode(spec), ext(pure)]
 fun is_x(foo: &Foo, x: u64): bool {
     foo.x == x
 }

--- a/crates/sui-prover/tests/inputs/quantifiers/loop_inv_count.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/loop_inv_count.ok.move
@@ -1,8 +1,8 @@
 module 0x42::loop_inv_count_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{invariant, ensures, requires};
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{count, count_range};
 
 
@@ -11,7 +11,7 @@ fun x_is_positive(x: &u64): bool {
     *x > 0
 }
 
-#[spec_only]
+#[mode(spec)]
 fun count_loop(v: &vector<u64>): u64 {
     let mut i = 0;
     let mut r = 0;

--- a/crates/sui-prover/tests/inputs/quantifiers/map.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/map.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_map_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::map;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/map_big.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/map_big.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_map_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::map;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/map_bpl.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/map_bpl.ok.move
@@ -1,13 +1,13 @@
 #[allow(unused)]
 module 0x42::quantifiers_map_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::map;
 
-#[spec_only]
+#[mode(spec)]
 native fun x_plus_10(x: &u64): u64;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/quantifiers/map_macro_loop.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/map_macro_loop.ok.move
@@ -16,7 +16,8 @@ fun flip(x: u64): u64 {
     std::u64::max_value!() - x
 }
 
-#[spec_only(loop_inv(target=map_flip)), ext(no_abort)]
+#[mode(spec), ext(spec(loop_inv(target=map_flip)), no_abort)]
+#[allow(unused_function)]
 fun map_flip_invariant(v: &vector<u64>, v__3: &vector<u64>, i: u64, stop: u64, r: &vector<u64>): bool {
     i <= stop
     && stop - i == v__3.length()

--- a/crates/sui-prover/tests/inputs/quantifiers/map_range.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/map_range.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_map_range_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::map_range;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/map_range.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/map_range.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_map_range_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::map_range;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/multiple_args.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/multiple_args.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::quantifiers_multiple_args;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{forall, exists, ensures};
 use prover::vector_iter::map;
 

--- a/crates/sui-prover/tests/inputs/quantifiers/nested_helpers.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/nested_helpers.ok.move
@@ -5,10 +5,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_nested_helpers_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{count, filter, map, sum_map, find_index};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/nested_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/nested_pure.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::nested_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{any, all, any_range, all_range, count, count_range, sum_map, sum_map_range, map, map_range, find_index, find_index_range, find, find_range, filter, filter_range, find_indices, find_indices_range};
 
 // Simple predicates

--- a/crates/sui-prover/tests/inputs/quantifiers/nested_pure_params.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/nested_pure_params.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::nested_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{any, all, any_range, all_range, count, count_range, sum_map, sum_map_range, map, map_range, find_index, find_index_range, find, find_range, filter, filter_range, find_indices, find_indices_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/not_function_param.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/not_function_param.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_not_function_param_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::map;
 
 

--- a/crates/sui-prover/tests/inputs/quantifiers/partial_pattern_exists.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/partial_pattern_exists.fail.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::quantifiers_partial_pattern_exists_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{end_exists_lambda, ensures};
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/quantifiers/partial_pattern_forall.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/partial_pattern_forall.fail.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::quantifiers_partial_pattern_forall_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{begin_forall_lambda, ensures};
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/quantifiers/partial_pattern_map.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/partial_pattern_map.fail.move
@@ -1,7 +1,7 @@
 #[allow(unused)]
 module 0x42::quantifiers_partial_pattern_map_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{begin_map_lambda};
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_count.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_count.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_count_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_count;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_count.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_count.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_count_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_count;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_count_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_count_pure.ok.move
@@ -1,13 +1,13 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_count_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_count;
 
-#[spec_only]
+#[mode(spec)]
 use std::integer::Integer;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_count_split.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_count_split.ok.move
@@ -5,10 +5,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_count_split_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_count;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_map.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_map.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_map_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_map;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_map.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_map.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_map_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_map;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_sum_map.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_sum_map.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_sum_map_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_sum_map;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_sum_map.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_sum_map.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_sum_map_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_sum_map;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_sum_map_bounding.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_sum_map_bounding.ok.move
@@ -7,10 +7,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_sum_map_bounding_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_sum_map;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_sum_map_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_sum_map_pure.ok.move
@@ -1,13 +1,13 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_sum_map_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_sum_map;
 
-#[spec_only]
+#[mode(spec)]
 use std::integer::Integer;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/range_sum_map_split.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/range_sum_map_split.ok.move
@@ -5,10 +5,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_range_sum_map_split_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range_sum_map;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/sum_map.fail.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/sum_map.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_sum_map_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{sum_map, sum_map_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/sum_map.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/sum_map.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_sum_map_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{sum_map, sum_map_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/sum_map_big.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/sum_map_big.ok.move
@@ -3,10 +3,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_sum_map_big_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::sum_map;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/sum_map_bounding.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/sum_map_bounding.ok.move
@@ -7,10 +7,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_sum_map_bounding_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{sum_map, sum_map_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/sum_map_singleton.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/sum_map_singleton.ok.move
@@ -5,10 +5,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_sum_map_singleton_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::sum_map_range;
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/quantifiers/sum_map_split.ok.move
+++ b/crates/sui-prover/tests/inputs/quantifiers/sum_map_split.ok.move
@@ -6,10 +6,10 @@
 #[allow(unused)]
 module 0x42::quantifiers_sum_map_split_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::{sum_map, sum_map_range};
 
 #[ext(pure)]

--- a/crates/sui-prover/tests/inputs/reals.fail.move
+++ b/crates/sui-prover/tests/inputs/reals.fail.move
@@ -7,7 +7,7 @@ public fun foo(x: u64): u64 {
   x + 1
 }
 
-#[spec_only]
+#[mode(spec)]
 fun show_real(the_real: std::real::Real): std::real::Real {
   the_real
 }

--- a/crates/sui-prover/tests/inputs/recursion.ok.move
+++ b/crates/sui-prover/tests/inputs/recursion.ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 // not inlined

--- a/crates/sui-prover/tests/inputs/recursion_mutual.fail.move
+++ b/crates/sui-prover/tests/inputs/recursion_mutual.fail.move
@@ -1,6 +1,6 @@
 module 0x42::recursion_mutual_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun factorial_helper(x: u64): u64 {

--- a/crates/sui-prover/tests/inputs/recursion_simple.fail.move
+++ b/crates/sui-prover/tests/inputs/recursion_simple.fail.move
@@ -1,6 +1,6 @@
 module 0x42::recursion_simple_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun factorial(x: u64): u64 {

--- a/crates/sui-prover/tests/inputs/scenario/scenario_abort.fail.move
+++ b/crates/sui-prover/tests/inputs/scenario/scenario_abort.fail.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 fun foo(a: u128): bool {

--- a/crates/sui-prover/tests/inputs/scenario/scenario_ignore_abort.ok.move
+++ b/crates/sui-prover/tests/inputs/scenario/scenario_ignore_abort.ok.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 fun foo(a: u128): bool {

--- a/crates/sui-prover/tests/inputs/spec_dynamic_field/spec_dynamic_field_check.move
+++ b/crates/sui-prover/tests/inputs/spec_dynamic_field/spec_dynamic_field_check.move
@@ -14,7 +14,7 @@ module 0x42::dynamic_fields {
         field::borrow(&x.id, b"dfchild") == y
     }
 
-    #[spec_only]
+    #[mode(spec)]
     use prover::prover::requires;
 
     #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/spec_dynamic_field/spec_dynamic_object_check.move
+++ b/crates/sui-prover/tests/inputs/spec_dynamic_field/spec_dynamic_object_check.move
@@ -15,7 +15,7 @@ module 0x42::dynamic_fields {
         ofield::borrow(&x.id, b"dfochild") == y
     }
 
-    #[spec_only]
+    #[mode(spec)]
     use prover::prover::requires;
 
     #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/spec_limited/as_spec.fail.move
+++ b/crates/sui-prover/tests/inputs/spec_limited/as_spec.fail.move
@@ -1,7 +1,7 @@
 #[allow(unused_function)]
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 #[ext(no_abort)]

--- a/crates/sui-prover/tests/inputs/spec_limited/nested_spec.ok.move
+++ b/crates/sui-prover/tests/inputs/spec_limited/nested_spec.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused_function)]
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 fun sum(x: u32, y: u32): u64 {
     (x as u64) + (y as u64)
 }

--- a/crates/sui-prover/tests/inputs/spec_only_deprecated.fail.move
+++ b/crates/sui-prover/tests/inputs/spec_only_deprecated.fail.move
@@ -1,0 +1,14 @@
+module 0x42::spec_only_deprecated_test;
+
+// #[spec_only] has been replaced by #[mode(spec)] and should produce an error
+#[spec_only]
+native fun helper(): u64;
+
+public fun foo(): u64 {
+    1
+}
+
+#[spec(prove)]
+public fun foo_spec(): u64 {
+    foo()
+}

--- a/crates/sui-prover/tests/inputs/spec_paths/duplicate_target.move
+++ b/crates/sui-prover/tests/inputs/spec_paths/duplicate_target.move
@@ -5,7 +5,7 @@ module 0x42::foo {
 }
 
 module 0x43::foo_spec {
-    #[spec_only]
+    #[mode(spec)]
     use prover::prover::{ensures, requires};
     use 0x42::foo::inc;
 

--- a/crates/sui-prover/tests/inputs/spec_paths/fun_not_found.move
+++ b/crates/sui-prover/tests/inputs/spec_paths/fun_not_found.move
@@ -6,7 +6,7 @@ module 0x42::foo {
 
 
 module 0x43::foo_spec {
-    #[spec_only]
+    #[mode(spec)]
     use prover::prover::{ensures, requires};
     use 0x42::foo::inc;
 

--- a/crates/sui-prover/tests/inputs/spec_paths/path.ok.move
+++ b/crates/sui-prover/tests/inputs/spec_paths/path.ok.move
@@ -5,7 +5,7 @@ module 0x42::foo {
 }
 
 module 0x43::foo_spec {
-    #[spec_only]
+    #[mode(spec)]
     use prover::prover::{ensures, requires};
     use 0x42::foo;
 

--- a/crates/sui-prover/tests/inputs/spec_paths/scenario.ok.move
+++ b/crates/sui-prover/tests/inputs/spec_paths/scenario.ok.move
@@ -5,7 +5,7 @@ module 0x42::foo {
 }
 
 module 0x43::foo_spec {
-    #[spec_only]
+    #[mode(spec)]
     use prover::prover::{ensures, requires};
     use 0x42::foo::inc;
 

--- a/crates/sui-prover/tests/inputs/spec_paths/wrong_module.move
+++ b/crates/sui-prover/tests/inputs/spec_paths/wrong_module.move
@@ -5,7 +5,7 @@ module 0x42::foo {
 }
 
 module 0x43::foo_spec {
-    #[spec_only]
+    #[mode(spec)]
     use prover::prover::{ensures, requires};
     use 0x42::foo;
 

--- a/crates/sui-prover/tests/inputs/spec_purity/spec_purity_event_module.move
+++ b/crates/sui-prover/tests/inputs/spec_purity/spec_purity_event_module.move
@@ -14,7 +14,7 @@ module 0x42::dynamic_fields {
         event::emit(TestEvent { value: x });
     }
 
-    #[spec_only]
+    #[mode(spec)]
     use prover::prover::ensures;
 
     #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/spec_purity/spec_purity_mut_ref.move
+++ b/crates/sui-prover/tests/inputs/spec_purity/spec_purity_mut_ref.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo() {

--- a/crates/sui-prover/tests/inputs/spec_purity/spec_purity_scenario_check.move
+++ b/crates/sui-prover/tests/inputs/spec_purity/spec_purity_scenario_check.move
@@ -5,7 +5,7 @@ fun foo(x: &mut u64) {
   *x = *x + 1;
 }
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/spec_purity/spec_purity_transfer_module.move
+++ b/crates/sui-prover/tests/inputs/spec_purity/spec_purity_transfer_module.move
@@ -9,7 +9,7 @@ module 0x42::dynamic_fields {
         u128::sqrt(x) as u64
     }
 
-    #[spec_only]
+    #[mode(spec)]
     use prover::prover::ensures;
 
     #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_datatype_inv_spec.fail.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_datatype_inv_spec.fail.move
@@ -2,10 +2,11 @@ module 0x42::bad_inv;
 
 public struct S { x: u8 }
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
+#[allow(unused_function)]
 fun S_inv(self: &S): bool {
     self.get_y() > 0
 }

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_few_func_call.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_few_func_call.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo<T>() {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_func_conditions.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_func_conditions.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ ensures, asserts, requires };
 
 public fun foo(a: u8) {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_func_execution.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_func_execution.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo(a: u8) {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_no_func_call.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_no_func_call.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo<T>() {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_param_order_mismatch.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_param_order_mismatch.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{requires, ensures};
 
 public fun add_up(x: u8, y: u8): u8 {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_params_attr.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_params_attr.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo(x: u64): u64 {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_params_count.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_params_count.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo() {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_params_names.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_params_names.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo(x: u64): u64 {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_params_types.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_params_types.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo(x: u128) {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_return_att.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_return_att.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo(x: u64): u64 {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_return_types.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_return_types.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo(x: u128): u128 {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_return_types_count.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_return_types_count.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo(x: u128) {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_type_params_count.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_type_params_count.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo<T>() {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_type_params_order.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_type_params_order.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo<T, K>() {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_type_params_using.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_type_params_using.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public fun foo<T>() {

--- a/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_warn_order.move
+++ b/crates/sui-prover/tests/inputs/spec_well_formed/spec_well_formed_warn_order.move
@@ -1,6 +1,6 @@
 module 0x42::foo;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::asserts;
 
 fun add(x: u64, _y: u64): u64 {

--- a/crates/sui-prover/tests/inputs/sum_slice_range/range.fail.move
+++ b/crates/sui-prover/tests/inputs/sum_slice_range/range.fail.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::range_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/sum_slice_range/range.ok.move
+++ b/crates/sui-prover/tests/inputs/sum_slice_range/range.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::range_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use prover::vector_iter::range;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/table_ext/add_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/table_ext/add_pure.ok.move
@@ -3,10 +3,10 @@ module 0x42::table_ext_add_pure_ok;
 
 use sui::table::Table;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use sui::table::add_pure;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/table_ext/borrow_or_unknown.fail.move
+++ b/crates/sui-prover/tests/inputs/table_ext/borrow_or_unknown.fail.move
@@ -3,10 +3,10 @@ module 0x42::table_ext_borrow_or_unknown_fail;
 
 use sui::table::Table;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::table::borrow_or_unknown;
 
 // For an absent key, borrow_or_unknown returns an uninterpreted value —

--- a/crates/sui-prover/tests/inputs/table_ext/borrow_or_unknown.ok.move
+++ b/crates/sui-prover/tests/inputs/table_ext/borrow_or_unknown.ok.move
@@ -3,10 +3,10 @@ module 0x42::table_ext_borrow_or_unknown_ok;
 
 use sui::table::Table;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::table::borrow_or_unknown;
 
 // Contained key: borrow_or_unknown agrees with table::borrow.

--- a/crates/sui-prover/tests/inputs/table_ext/remove_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/table_ext/remove_pure.ok.move
@@ -3,10 +3,10 @@ module 0x42::table_ext_remove_pure_ok;
 
 use sui::table::Table;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use sui::table::remove_pure;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/test_only_attr.ok.move
+++ b/crates/sui-prover/tests/inputs/test_only_attr.ok.move
@@ -3,7 +3,7 @@ module 0x42::working_test;
 
 use sui::test_utils::destroy; // check test imports
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{asserts, requires, ensures};
 
 #[test_only] // check test_only attribute visibility

--- a/crates/sui-prover/tests/inputs/type_name/type_name_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/type_name/type_name_pure.ok.move
@@ -4,7 +4,7 @@
 module 0x42::type_name_pure;
 
 use std::type_name;
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
 public struct MyCoin has drop {}

--- a/crates/sui-prover/tests/inputs/uninterpreted/native_generic.ok.move
+++ b/crates/sui-prover/tests/inputs/uninterpreted/native_generic.ok.move
@@ -3,7 +3,7 @@ module 0x42::foo;
 use prover::prover::ensures;
 
 #[ext(pure)]
-#[spec_only]
+#[mode(spec)]
 native fun bar<T1, T2>(x: u64): u64;
 
 fun foo(x: u64): u64 {

--- a/crates/sui-prover/tests/inputs/uninterpreted/native_simple.ok.move
+++ b/crates/sui-prover/tests/inputs/uninterpreted/native_simple.ok.move
@@ -3,7 +3,7 @@ module 0x42::foo;
 use prover::prover::ensures;
 
 #[ext(pure)]
-#[spec_only]
+#[mode(spec)]
 native fun bar(): u64;
 
 fun foo(): u64 {

--- a/crates/sui-prover/tests/inputs/vec_map_ext/get_entry_by_idx_or_unknown.fail.move
+++ b/crates/sui-prover/tests/inputs/vec_map_ext/get_entry_by_idx_or_unknown.fail.move
@@ -3,10 +3,10 @@ module 0x42::vec_map_ext_get_entry_by_idx_or_unknown_fail;
 
 use sui::vec_map;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::vec_map::get_entry_by_idx_or_unknown;
 
 // For an out-of-range index, get_entry_by_idx_or_unknown returns an

--- a/crates/sui-prover/tests/inputs/vec_map_ext/get_entry_by_idx_or_unknown.ok.move
+++ b/crates/sui-prover/tests/inputs/vec_map_ext/get_entry_by_idx_or_unknown.ok.move
@@ -3,10 +3,10 @@ module 0x42::vec_map_ext_get_entry_by_idx_or_unknown_ok;
 
 use sui::vec_map;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::vec_map::get_entry_by_idx_or_unknown;
 
 // In-range: get_entry_by_idx_or_unknown agrees with vec_map::get_entry_by_idx.

--- a/crates/sui-prover/tests/inputs/vec_map_ext/get_idx_or_unknown.ok.move
+++ b/crates/sui-prover/tests/inputs/vec_map_ext/get_idx_or_unknown.ok.move
@@ -3,10 +3,10 @@ module 0x42::vec_map_ext_get_idx_or_unknown_ok;
 
 use sui::vec_map;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::vec_map::get_idx_or_unknown;
 
 // Contained key: get_idx_or_unknown agrees with vec_map::get_idx.

--- a/crates/sui-prover/tests/inputs/vec_map_ext/get_or_unknown.fail.move
+++ b/crates/sui-prover/tests/inputs/vec_map_ext/get_or_unknown.fail.move
@@ -3,10 +3,10 @@ module 0x42::vec_map_ext_get_or_unknown_fail;
 
 use sui::vec_map;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::vec_map::get_or_unknown;
 
 // For an absent key, get_or_unknown returns an uninterpreted value —

--- a/crates/sui-prover/tests/inputs/vec_map_ext/get_or_unknown.ok.move
+++ b/crates/sui-prover/tests/inputs/vec_map_ext/get_or_unknown.ok.move
@@ -3,10 +3,10 @@ module 0x42::vec_map_ext_get_or_unknown_ok;
 
 use sui::vec_map;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use sui::vec_map::get_or_unknown;
 
 // Contained key: get_or_unknown agrees with vec_map::get.

--- a/crates/sui-prover/tests/inputs/vec_map_ext/insert_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vec_map_ext/insert_pure.ok.move
@@ -3,10 +3,10 @@ module 0x42::vec_map_ext_insert_pure_ok;
 
 use sui::vec_map;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use sui::vec_map::insert_pure;
 
 // After insert, the functional model equals the mutable result.

--- a/crates/sui-prover/tests/inputs/vec_map_ext/remove_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vec_map_ext/remove_pure.ok.move
@@ -3,10 +3,10 @@ module 0x42::vec_map_ext_remove_pure_ok;
 
 use sui::vec_map;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use sui::vec_map::remove_pure;
 
 // After remove of a contained key, the functional model equals the result.

--- a/crates/sui-prover/tests/inputs/vec_set_ext/insert_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vec_set_ext/insert_pure.ok.move
@@ -3,10 +3,10 @@ module 0x42::vec_set_ext_insert_pure_ok;
 
 use sui::vec_set;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use sui::vec_set::insert_pure;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/vec_set_ext/remove_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vec_set_ext/remove_pure.ok.move
@@ -3,10 +3,10 @@ module 0x42::vec_set_ext_remove_pure_ok;
 
 use sui::vec_set;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use sui::vec_set::remove_pure;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/vector_ext/append_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vector_ext/append_pure.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::vector_ext_append_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, clone};
 
-#[spec_only]
+#[mode(spec)]
 use std::vector::append_pure;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/vector_ext/borrow_or_unknown.fail.move
+++ b/crates/sui-prover/tests/inputs/vector_ext/borrow_or_unknown.fail.move
@@ -5,10 +5,10 @@
 #[allow(unused)]
 module 0x42::vector_ext_borrow_or_unknown_fail;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
 
-#[spec_only]
+#[mode(spec)]
 use std::vector::borrow_or_unknown;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/vector_ext/borrow_or_unknown.ok.move
+++ b/crates/sui-prover/tests/inputs/vector_ext/borrow_or_unknown.ok.move
@@ -4,10 +4,10 @@
 #[allow(unused)]
 module 0x42::vector_ext_borrow_or_unknown_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use std::vector::borrow_or_unknown;
 
 // In-range: borrow_or_unknown agrees with vector::borrow.

--- a/crates/sui-prover/tests/inputs/vector_ext/insert_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vector_ext/insert_pure.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::vector_ext_insert_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use std::vector::insert_pure;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/vector_ext/pop_back_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vector_ext/pop_back_pure.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::vector_ext_pop_back_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use std::vector::pop_back_pure;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/vector_ext/pop_front_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vector_ext/pop_front_pure.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::vector_ext_pop_front_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires};
 
-#[spec_only]
+#[mode(spec)]
 use std::vector::pop_front_pure;
 
 // Length of pop_front on a non-empty vector is length - 1.

--- a/crates/sui-prover/tests/inputs/vector_ext/push_back_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vector_ext/push_back_pure.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::vector_ext_push_back_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use std::vector::push_back_pure;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/inputs/vector_ext/push_front_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vector_ext/push_front_pure.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::vector_ext_push_front_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, clone};
 
-#[spec_only]
+#[mode(spec)]
 use std::vector::push_front_pure;
 
 // New first element equals the pushed element.

--- a/crates/sui-prover/tests/inputs/vector_ext/remove_pure.ok.move
+++ b/crates/sui-prover/tests/inputs/vector_ext/remove_pure.ok.move
@@ -1,10 +1,10 @@
 #[allow(unused)]
 module 0x42::vector_ext_remove_pure_ok;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, requires, clone};
 
-#[spec_only]
+#[mode(spec)]
 use std::vector::remove_pure;
 
 #[spec(prove)]

--- a/crates/sui-prover/tests/integration.rs
+++ b/crates/sui-prover/tests/integration.rs
@@ -6,6 +6,7 @@ use move_package::BuildConfig as MoveBuildConfig;
 use move_prover_boogie_backend::{
     generator::run_move_prover_with_model, generator_options::Options,
 };
+use move_stackless_bytecode::attr_query::SPEC_MODE;
 use regex::Regex;
 use std::fs::{copy, create_dir_all, read_to_string};
 use std::path::{Path, PathBuf};
@@ -102,7 +103,7 @@ integration-test = "0x9"
         let mut config = MoveBuildConfig::default();
         config.default_flavor = Some(Flavor::Sui);
         config.silence_warnings = false; // Disable warning suppression
-        config.modes = vec![ModeAttribute::VERIFY_ONLY.into()];
+        config.modes = vec![ModeAttribute::VERIFY_ONLY.into(), SPEC_MODE.into()];
         config.skip_fetch_latest_git_deps = true;
 
         // Try to build the model (using unlocked version for parallel test execution)

--- a/crates/sui-prover/tests/snapshots/axioms/calling_proc.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/axioms/calling_proc.fail.move.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/sui-prover/tests/integration.rs
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
 error: Function 'simple_axiom::bar' called from a pure function cannot abort
-   ┌─ tests/inputs/axioms/calling_proc.fail.move:12:5
+   ┌─ tests/inputs/axioms/calling_proc.fail.move:13:5
    │
-12 │     assert!(1u8 > 2u8);
+13 │     assert!(1u8 > 2u8);
    │     ^^^^^^^^^^^^^^^^^^

--- a/crates/sui-prover/tests/snapshots/axioms/mut_ref.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/axioms/mut_ref.fail.move.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 267
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
 warning: unused mutable reference '&mut' parameter
-  ┌─ tests/inputs/axioms/mut_ref.fail.move:6:16
+  ┌─ tests/inputs/axioms/mut_ref.fail.move:7:16
   │
-6 │ fun f_axiom(x: &mut u64): bool {
+7 │ fun f_axiom(x: &mut u64): bool {
   │             -  ^^^^^^^^ Mutable reference is never used mutably, consider switching to an immutable reference '&' instead
   │             │   
   │             For parameters, this can be silenced by prefixing the name with an underscore, e.g. '_x'
@@ -15,9 +15,9 @@ warning: unused mutable reference '&mut' parameter
   = This warning can be suppressed with '#[allow(unused_mut_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error: Axiom functions cannot have mutable reference parameters: 'x'
-  ┌─ tests/inputs/axioms/mut_ref.fail.move:6:1
+  ┌─ tests/inputs/axioms/mut_ref.fail.move:7:1
   │  
-6 │ ╭ fun f_axiom(x: &mut u64): bool {
-7 │ │     *x > 4 && (*x).to_int().sqrt().gt(2u64.to_int())
-8 │ │ }
+7 │ ╭ fun f_axiom(x: &mut u64): bool {
+8 │ │     *x > 4 && (*x).to_int().sqrt().gt(2u64.to_int())
+9 │ │ }
   │ ╰─^

--- a/crates/sui-prover/tests/snapshots/axioms/returns.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/axioms/returns.fail.move.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 267
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
 error: Axiom functions should return bool type
-  ┌─ tests/inputs/axioms/returns.fail.move:7:1
-  │  
-7 │ ╭ fun f_axiom(x: u64): Integer {
-8 │ │     x.to_int().sqrt()
-9 │ │ }
-  │ ╰─^
+   ┌─ tests/inputs/axioms/returns.fail.move:8:1
+   │  
+ 8 │ ╭ fun f_axiom(x: u64): Integer {
+ 9 │ │     x.to_int().sqrt()
+10 │ │ }
+   │ ╰─^

--- a/crates/sui-prover/tests/snapshots/ext_spec_requires_mode.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/ext_spec_requires_mode.fail.move.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 298
+expression: output
+---
+exiting with bytecode transformation errors
+error: #[ext(spec(...))] on 'ext_spec_requires_mode_test::helper' requires #[mode(spec)]
+  ┌─ tests/inputs/ext_spec_requires_mode.fail.move:5:1
+  │  
+5 │ ╭ fun helper(): bool {
+6 │ │     true
+7 │ │ }
+  │ ╰─^

--- a/crates/sui-prover/tests/snapshots/inv/recursive_type_inv.move.snap
+++ b/crates/sui-prover/tests/snapshots/inv/recursive_type_inv.move.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 277
+assertion_line: 298
 expression: output
 ---
 exiting with model building errors
 error: cyclic data
-   ┌─ tests/inputs/inv/recursive_type_inv.move:22:21
+   ┌─ tests/inputs/inv/recursive_type_inv.move:23:21
    │
-22 │     c_field: vector<C>,
+23 │     c_field: vector<C>,
    │                     ^
    │                     │
    │                     Invalid field containing 'C' in struct 'B'.

--- a/crates/sui-prover/tests/snapshots/inv_paths/duplicate_target.move.snap
+++ b/crates/sui-prover/tests/snapshots/inv_paths/duplicate_target.move.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/sui-prover/tests/integration.rs
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
 error: Duplicate invariant declaration for struct: Bar
-   ┌─ tests/inputs/inv_paths/duplicate_target.move:29:5
+   ┌─ tests/inputs/inv_paths/duplicate_target.move:31:5
    │  
-29 │ ╭     fun foobar(bar: &Bar): bool {
-30 │ │         bar.get_values() < 250
-31 │ │     }
+31 │ ╭     fun foobar(bar: &Bar): bool {
+32 │ │         bar.get_values() < 250
+33 │ │     }
    │ ╰─────^

--- a/crates/sui-prover/tests/snapshots/inv_paths/inv_path.ok.move.snap
+++ b/crates/sui-prover/tests/snapshots/inv_paths/inv_path.ok.move.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/sui-prover/tests/integration.rs
+assertion_line: 298
 expression: output
 ---
 exiting with verification errors
 error: prover::ensures does not hold
-   ┌─ tests/inputs/inv_paths/inv_path.ok.move:31:5
+   ┌─ tests/inputs/inv_paths/inv_path.ok.move:32:5
    │
-31 │     }
+32 │     }
    │     ^
    │
-   =     at tests/inputs/inv_paths/inv_path.ok.move:29: increment_spec
+   =     at tests/inputs/inv_paths/inv_path.ok.move:30: increment_spec

--- a/crates/sui-prover/tests/snapshots/inv_paths/struct_not_found.move.snap
+++ b/crates/sui-prover/tests/snapshots/inv_paths/struct_not_found.move.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/sui-prover/tests/integration.rs
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
 error: Target struct 'Baz' not found in module '0x43::inv_path_foo_spec'
-   ┌─ tests/inputs/inv_paths/struct_not_found.move:24:5
+   ┌─ tests/inputs/inv_paths/struct_not_found.move:25:5
    │  
-24 │ ╭     fun foo(bar: &Bar): bool {
-25 │ │         bar.get_values() < 150
-26 │ │     }
+25 │ ╭     fun foo(bar: &Bar): bool {
+26 │ │         bar.get_values() < 150
+27 │ │     }
    │ ╰─────^

--- a/crates/sui-prover/tests/snapshots/loop_invariant/base_case_fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/loop_invariant/base_case_fail.move.snap
@@ -1,19 +1,19 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 292
+assertion_line: 298
 expression: output
 ---
 exiting with verification errors
 error: prover::ensures does not hold
-   ┌─ tests/inputs/loop_invariant/base_case_fail.move:8:1
+   ┌─ tests/inputs/loop_invariant/base_case_fail.move:9:1
    │  
- 8 │ ╭ fun loop_inv_0(i: u64, n: u64): bool {
- 9 │ │     // This invariant is wrong at entry: i starts at 0, but we claim i > 0.
-10 │ │     i > 0 && i <= n
-11 │ │ }
+ 9 │ ╭ fun loop_inv_0(i: u64, n: u64): bool {
+10 │ │     // This invariant is wrong at entry: i starts at 0, but we claim i > 0.
+11 │ │     i > 0 && i <= n
+12 │ │ }
    │ ╰─^
    · │
-16 │       while (i < n) {
+17 │       while (i < n) {
    │              - loop invariant does not hold on loop entry
    │  
-   =     at tests/inputs/loop_invariant/base_case_fail.move:14: foo_spec
+   =     at tests/inputs/loop_invariant/base_case_fail.move:15: foo_spec

--- a/crates/sui-prover/tests/snapshots/loop_invariant/external_aborts.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/loop_invariant/external_aborts.fail.move.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 262
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
 error: Invariant function should not abort
-  ┌─ tests/inputs/loop_invariant/external_aborts.fail.move:6:1
+  ┌─ tests/inputs/loop_invariant/external_aborts.fail.move:7:1
   │  
-6 │ ╭ fun loop_inv(i: u64, n: u64, s: u128): bool {
-7 │ │     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
-8 │ │ }
+7 │ ╭ fun loop_inv(i: u64, n: u64, s: u128): bool {
+8 │ │     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
+9 │ │ }
   │ ╰─^

--- a/crates/sui-prover/tests/snapshots/loop_invariant/external_inv_aborts.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/loop_invariant/external_inv_aborts.fail.move.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 262
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
 error: Invariant function should not abort
-  ┌─ tests/inputs/loop_invariant/external_inv_aborts.fail.move:6:1
+  ┌─ tests/inputs/loop_invariant/external_inv_aborts.fail.move:7:1
   │  
-6 │ ╭ fun loop_inv(i: u64, n: u64, s: u128): bool {
-7 │ │     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
-8 │ │ }
+7 │ ╭ fun loop_inv(i: u64, n: u64, s: u128): bool {
+8 │ │     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
+9 │ │ }
   │ ╰─^

--- a/crates/sui-prover/tests/snapshots/loop_invariant/external_mut_ref.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/loop_invariant/external_mut_ref.fail.move.snap
@@ -1,19 +1,9 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 262
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
-warning: unused mutable reference '&mut' parameter
-  ┌─ tests/inputs/loop_invariant/external_mut_ref.fail.move:7:33
-  │
-7 │ fun loop_inv(i: u64, n: u64, s: &mut u128): bool {
-  │                              -  ^^^^^^^^^ Mutable reference is never used mutably, consider switching to an immutable reference '&' instead
-  │                              │   
-  │                              For parameters, this can be silenced by prefixing the name with an underscore, e.g. '_s'
-  │
-  = This warning can be suppressed with '#[allow(unused_mut_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
 error: Mutable references are not allowed in loop invariant functions
   ┌─ tests/inputs/loop_invariant/external_mut_ref.fail.move:7:1
   │  

--- a/crates/sui-prover/tests/snapshots/loop_invariant/external_no_target.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/loop_invariant/external_no_target.fail.move.snap
@@ -1,15 +1,9 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 262
+assertion_line: 298
 expression: output
 ---
-exiting with model building errors
-error: invalid usage of known attribute
-  ┌─ tests/inputs/loop_invariant/external_no_target.fail.move:5:3
-  │
-5 │ #[spec_only(loop_inv(label = 0))]
-  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing required attribute 'target' for loop_inv.
-
+exiting with bytecode transformation errors
 warning: unused function
   ┌─ tests/inputs/loop_invariant/external_no_target.fail.move:6:5
   │
@@ -17,3 +11,11 @@ warning: unused function
   │     ^^^^^^^^ The non-'public', non-'entry' function 'loop_inv' is never called. Consider removing it.
   │
   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error: `loop_inv` in #[ext(spec(...))] requires a `target` parameter
+  ┌─ tests/inputs/loop_invariant/external_no_target.fail.move:6:1
+  │  
+6 │ ╭ fun loop_inv(i: u64, n: u64, s: u128): bool {
+7 │ │     i <= n && (s == (i as u128) * ((i as u128) + 1) / 2)
+8 │ │ }
+  │ ╰─^

--- a/crates/sui-prover/tests/snapshots/loop_invariant/external_return_type.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/loop_invariant/external_return_type.fail.move.snap
@@ -1,25 +1,9 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 262
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
-warning: unused variable
-  ┌─ tests/inputs/loop_invariant/external_return_type.fail.move:7:14
-  │
-7 │ fun loop_inv(i: u64, n: u64, s: u128): u64 {
-  │              ^ Unused parameter 'i'. Consider removing or prefixing with an underscore: '_i'
-  │
-  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning: unused variable
-  ┌─ tests/inputs/loop_invariant/external_return_type.fail.move:7:30
-  │
-7 │ fun loop_inv(i: u64, n: u64, s: u128): u64 {
-  │                              ^ Unused parameter 's'. Consider removing or prefixing with an underscore: '_s'
-  │
-  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
 error: Loop invariant functions must return a boolean value
    ┌─ tests/inputs/loop_invariant/external_return_type.fail.move:7:1
    │  

--- a/crates/sui-prover/tests/snapshots/loop_invariant/issue-416.move.snap
+++ b/crates/sui-prover/tests/snapshots/loop_invariant/issue-416.move.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 297
+assertion_line: 298
 expression: output
 ---
 exiting with verification errors
 error: prover::ensures does not hold
-    ┌─ tests/inputs/loop_invariant/issue-416.move:12:1
+    ┌─ tests/inputs/loop_invariant/issue-416.move:13:1
     │  
- 12 │ ╭ fun bar_loop_inv(i: u64, stop: u64, v__3: &vector<u8>, v: &vector<u8>, r: &vector<u8>): bool {
- 13 │ │     i <= stop && v__3.length() == stop - i && r == map_range!(v, 0, i, |x| flip(x))
- 14 │ │         && !exists!(|j| more_loop_inv_3(*j, v, v__3))
- 15 │ │ }
+ 13 │ ╭ fun bar_loop_inv(i: u64, stop: u64, v__3: &vector<u8>, v: &vector<u8>, r: &vector<u8>): bool {
+ 14 │ │     i <= stop && v__3.length() == stop - i && r == map_range!(v, 0, i, |x| flip(x))
+ 15 │ │         && !exists!(|j| more_loop_inv_3(*j, v, v__3))
+ 16 │ │ }
     │ ╰─^
     │  
     ┌─ /NORMALIZED_HOME/.move/https___github_com_asymptotic-code_sui_git_NORMALIZED/crates/sui-framework/packages/move-stdlib/sources/macros.move:180:12
@@ -18,4 +18,4 @@ error: prover::ensures does not hold
 180 │     while (i < stop) {
     │            - loop invariant is not preserved by the loop body
     │
-    =     at tests/inputs/loop_invariant/issue-416.move:22: bar_spec
+    =     at tests/inputs/loop_invariant/issue-416.move:23: bar_spec

--- a/crates/sui-prover/tests/snapshots/loop_invariant/issue-466.move.snap
+++ b/crates/sui-prover/tests/snapshots/loop_invariant/issue-466.move.snap
@@ -1,20 +1,21 @@
 ---
 source: crates/sui-prover/tests/integration.rs
+assertion_line: 298
 expression: output
 ---
 Verification successful
 warning: unused variable
-   ┌─ tests/inputs/loop_invariant/issue-466.move:21:18
+   ┌─ tests/inputs/loop_invariant/issue-466.move:22:18
    │
-21 │ fun f2_invariant(i: u64, length: u64, t: &T, __old_t: &T): bool {
+22 │ fun f2_invariant(i: u64, length: u64, t: &T, __old_t: &T): bool {
    │                  ^ Unused parameter 'i'. Consider removing or prefixing with an underscore: '_i'
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning: unused variable
-   ┌─ tests/inputs/loop_invariant/issue-466.move:21:26
+   ┌─ tests/inputs/loop_invariant/issue-466.move:22:26
    │
-21 │ fun f2_invariant(i: u64, length: u64, t: &T, __old_t: &T): bool {
+22 │ fun f2_invariant(i: u64, length: u64, t: &T, __old_t: &T): bool {
    │                          ^^^^^^ Unused parameter 'length'. Consider removing or prefixing with an underscore: '_length'
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/crates/sui-prover/tests/snapshots/spec_only_deprecated.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/spec_only_deprecated.fail.move.snap
@@ -1,0 +1,11 @@
+---
+source: crates/sui-prover/tests/integration.rs
+assertion_line: 298
+expression: output
+---
+exiting with bytecode transformation errors
+error: #[spec_only] is no longer supported; use #[mode(spec)] (move parameters into #[ext(spec(...))])
+  ┌─ tests/inputs/spec_only_deprecated.fail.move:5:1
+  │
+5 │ native fun helper(): u64;
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/sui-prover/tests/snapshots/spec_well_formed/spec_well_formed_datatype_inv_spec.fail.move.snap
+++ b/crates/sui-prover/tests/snapshots/spec_well_formed/spec_well_formed_datatype_inv_spec.fail.move.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/sui-prover/tests/integration.rs
-assertion_line: 275
+assertion_line: 298
 expression: output
 ---
 exiting with bytecode transformation errors
 error: Consider avoiding functions with specs in datatype invariants
-   ┌─ tests/inputs/spec_well_formed/spec_well_formed_datatype_inv_spec.fail.move:9:1
+   ┌─ tests/inputs/spec_well_formed/spec_well_formed_datatype_inv_spec.fail.move:10:1
    │  
- 9 │ ╭ fun S_inv(self: &S): bool {
-10 │ │     self.get_y() > 0
-11 │ │ }
+10 │ ╭ fun S_inv(self: &S): bool {
+11 │ │     self.get_y() > 0
+12 │ │ }
    │ ╰─^

--- a/packages/prover/sources/ghost.move
+++ b/packages/prover/sources/ghost.move
@@ -1,12 +1,12 @@
 module prover::ghost;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover;
 
-#[spec_only]
+#[mode(spec)]
 public native fun global<T, U>(): &U;
 
-#[spec_only]
+#[mode(spec)]
 public native fun set<T, U>(x: &U);
 
 #[spec]
@@ -16,14 +16,14 @@ public fun set_spec<T, U>(x: &U) {
   prover::ensures(global<T, U>() == x);
 }
 
-#[spec_only]
+#[mode(spec)]
 public native fun borrow_mut<T, U>(): &mut U;
 
-#[spec_only]
+#[mode(spec)]
 public native fun declare_global<T, U>();
-#[spec_only]
+#[mode(spec)]
 public native fun declare_global_mut<T, U>();
 
-#[spec_only]
+#[mode(spec)]
 #[allow(unused)]
 native fun havoc_global<T, U>();

--- a/packages/prover/sources/log.move
+++ b/packages/prover/sources/log.move
@@ -1,10 +1,10 @@
 module prover::log;
 
-#[spec_only]
+#[mode(spec)]
 public native fun text(x: vector<u8>);
 
-#[spec_only]
+#[mode(spec)]
 public native fun var<T>(x: &T);
 
-#[spec_only]
+#[mode(spec)]
 public native fun ghost<T, U>();

--- a/packages/prover/sources/prover.move
+++ b/packages/prover/sources/prover.move
@@ -1,28 +1,28 @@
 module prover::prover;
 
-#[spec_only]
+#[mode(spec)]
 native public fun requires(p: bool);
-#[spec_only]
+#[mode(spec)]
 native public fun ensures(p: bool);
-#[spec_only]
+#[mode(spec)]
 native public fun asserts(p: bool);
-#[spec_only]
+#[mode(spec)]
 native public fun asserts_of(name: vector<u8>): bool;
 
 /// Emits `assume {:split_here} true;` — cuts the VC at this point.
-#[spec_only]
+#[mode(spec)]
 native public fun boogie_split_here();
 
 /// Emits `assume {:focus} true;` — splits into "through here" vs "not through here" VCs.
-#[spec_only]
+#[mode(spec)]
 native public fun boogie_focus();
 
 /// Annotates the next `if` with `{:allow_path_isolation}`.
 /// Use with `boogie_opt = b"{:isolate_paths}"` on the spec.
-#[spec_only]
+#[mode(spec)]
 native public fun boogie_allow_path_isolation();
 
-#[spec_only]
+#[mode(spec)]
 public macro fun invariant($invariants: ||) {
     invariant_begin();
     $invariants();
@@ -33,12 +33,12 @@ public fun implies(p: bool, q: bool): bool {
     !p || q
 }
 
-#[spec_only]
+#[mode(spec)]
 native public fun invariant_begin();
-#[spec_only]
+#[mode(spec)]
 native public fun invariant_end();
 
-#[spec_only]
+#[mode(spec)]
 native public fun val<T>(x: &T): T;
 #[spec]
 fun val_spec<T>(x: &T): T {
@@ -49,7 +49,7 @@ fun val_spec<T>(x: &T): T {
     result
 }
 
-#[spec_only]
+#[mode(spec)]
 native public fun ref<T>(x: T): &T;
 #[spec]
 fun ref_spec<T>(x: T): &T {
@@ -63,46 +63,46 @@ fun ref_spec<T>(x: T): &T {
     result
 }
 
-#[spec_only]
+#[mode(spec)]
 native public fun drop<T>(x: T);
 #[spec]
 fun drop_spec<T>(x: T) {
     drop(x);
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun clone<$T>($x: &$T): &$T {
     ref(val($x))
 }
 
-#[spec_only]
+#[mode(spec)]
 native public fun fresh<T>(): T;
 #[spec]
 fun fresh_spec<T>(): T {
     fresh()
 }
 
-#[spec_only]
+#[mode(spec)]
 #[allow(unused)]
 native fun type_inv<T>(x: &T): bool;
 
-#[spec_only]
+#[mode(spec)]
 public native fun begin_forall_lambda<T>(): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_forall_lambda(): bool;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_exists_lambda<T>(): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_exists_lambda(): bool;
 
-#[spec_only]
+#[mode(spec)]
 public macro fun forall<$T>($f: |&$T| -> bool): bool {
     let x: &$T = begin_forall_lambda<$T>();
     let _ = $f(x);
     end_forall_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun exists<$T>($f: |&$T| -> bool): bool {
     let x: &$T = begin_exists_lambda<$T>();
     let _ = $f(x);

--- a/packages/prover/sources/vector.move
+++ b/packages/prover/sources/vector.move
@@ -1,92 +1,92 @@
 module prover::vector_iter;
 
-#[spec_only]
+#[mode(spec)]
 use std::integer::Integer;
-#[spec_only]
+#[mode(spec)]
 use std::option::Option;
 
-#[spec_only]
+#[mode(spec)]
 public native fun begin_map_lambda<T>(v: &vector<T>): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_map_range_lambda<T>(v: &vector<T>, start: u64, end: u64): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_map_lambda<T>(): &vector<T>;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_filter_lambda<T>(v: &vector<T>): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_filter_range_lambda<T>(v: &vector<T>, start: u64, end: u64): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_filter_lambda<T>(): &vector<T>;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_find_lambda<T>(v: &vector<T>): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_find_range_lambda<T>(v: &vector<T>, start: u64, end: u64): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_find_lambda<T>(): &Option<T>;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_find_index_lambda<T>(v: &vector<T>): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_find_index_range_lambda<T>(v: &vector<T>, start: u64, end: u64): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_find_index_lambda(): Option<u64>;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_find_indices_lambda<T>(v: &vector<T>): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_find_indices_range_lambda<T>(v: &vector<T>, start: u64, end: u64): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_find_indices_lambda(): &vector<u64>;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_count_lambda<T>(v: &vector<T>): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_count_range_lambda<T>(v: &vector<T>, start: u64, end: u64): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_count_lambda(): u64;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_any_lambda<T>(v: &vector<T>): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_any_range_lambda<T>(v: &vector<T>, start: u64, end: u64): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_any_lambda(): bool;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_all_lambda<T>(v: &vector<T>): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_all_range_lambda<T>(v: &vector<T>, start: u64, end: u64): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_all_lambda(): bool;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_sum_map_lambda<T>(v: &vector<T>): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_sum_map_range_lambda<T>(v: &vector<T>, start: u64, end: u64): &T;
-#[spec_only]
+#[mode(spec)]
 public native fun end_sum_map_lambda<T>(): Integer;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_range_map_lambda(start: u64, end: u64): u64;
-#[spec_only]
+#[mode(spec)]
 public native fun end_range_map_lambda<T>(): &vector<T>;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_range_count_lambda(start: u64, end: u64): u64;
-#[spec_only]
+#[mode(spec)]
 public native fun end_range_count_lambda(): Integer;
-#[spec_only]
+#[mode(spec)]
 public native fun begin_range_sum_map_lambda(start: u64, end: u64): u64;
-#[spec_only]
+#[mode(spec)]
 public native fun end_range_sum_map_lambda<T>(): Integer;
 
-#[spec_only]
+#[mode(spec)]
 public native fun range(start: u64, end: u64): &vector<u64>;
 
-#[spec_only]
+#[mode(spec)]
 public native fun sum<T>(v: &vector<T>): Integer;
 
-#[spec_only]
+#[mode(spec)]
 public native fun sum_range<T>(v: &vector<T>, start: u64, end: u64): Integer;
 
-#[spec_only]
+#[mode(spec)]
 public native fun slice<T>(v: &vector<T>, start: u64, end: u64): &vector<T>;
 
 
 // advanced macros patterns over vectors
-#[spec_only]
+#[mode(spec)]
 public macro fun map<$T, $U>($v: &vector<$T>, $f: |&$T| -> $U): &vector<$U> {
     let v = $v;
     let x: &$T = begin_map_lambda<$T>(v);
@@ -94,7 +94,7 @@ public macro fun map<$T, $U>($v: &vector<$T>, $f: |&$T| -> $U): &vector<$U> {
     end_map_lambda<$U>()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun filter<$T>($v: &vector<$T>, $f: |&$T| -> bool): &vector<$T> {
     let v = $v;
     let x: &$T = begin_filter_lambda<$T>(v);
@@ -102,7 +102,7 @@ public macro fun filter<$T>($v: &vector<$T>, $f: |&$T| -> bool): &vector<$T> {
     end_filter_lambda<$T>()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun find<$T>($v: &vector<$T>, $f: |&$T| -> bool): &Option<$T> {
     let v = $v;
     let x: &$T = begin_find_lambda<$T>(v);
@@ -110,7 +110,7 @@ public macro fun find<$T>($v: &vector<$T>, $f: |&$T| -> bool): &Option<$T> {
     end_find_lambda<$T>()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun find_index<$T>($v: &vector<$T>, $f: |&$T| -> bool): Option<u64> {
     let v = $v;
     let x: &$T = begin_find_index_lambda<$T>(v);
@@ -118,7 +118,7 @@ public macro fun find_index<$T>($v: &vector<$T>, $f: |&$T| -> bool): Option<u64>
     end_find_index_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun find_indices<$T>($v: &vector<$T>, $f: |&$T| -> bool): &vector<u64> {
     let v = $v;
     let x: &$T = begin_find_indices_lambda<$T>(v);
@@ -126,7 +126,7 @@ public macro fun find_indices<$T>($v: &vector<$T>, $f: |&$T| -> bool): &vector<u
     end_find_indices_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun count<$T>($v: &vector<$T>, $f: |&$T| -> bool): u64 {
     let v = $v;
     let x: &$T = begin_count_lambda<$T>(v);
@@ -134,7 +134,7 @@ public macro fun count<$T>($v: &vector<$T>, $f: |&$T| -> bool): u64 {
     end_count_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun any<$T>($v: &vector<$T>, $f: |&$T| -> bool): bool {
     let v = $v;
     let x: &$T = begin_any_lambda<$T>(v);
@@ -142,7 +142,7 @@ public macro fun any<$T>($v: &vector<$T>, $f: |&$T| -> bool): bool {
     end_any_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun all<$T>($v: &vector<$T>, $f: |&$T| -> bool): bool {
     let v = $v;
     let x: &$T = begin_all_lambda<$T>(v);
@@ -150,7 +150,7 @@ public macro fun all<$T>($v: &vector<$T>, $f: |&$T| -> bool): bool {
     end_all_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun sum_map<$T, $U>($v: &vector<$T>, $f: |&$T| -> $U): Integer {
     let v = $v;
     let x: &$T = begin_sum_map_lambda<$T>(v);
@@ -159,7 +159,7 @@ public macro fun sum_map<$T, $U>($v: &vector<$T>, $f: |&$T| -> $U): Integer {
 }
 
 // advanced range versions
-#[spec_only]
+#[mode(spec)]
 public macro fun map_range<$T, $U>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T| -> $U): &vector<$U> {
     let v = $v;
     let x: &$T = begin_map_range_lambda<$T>(v, $start, $end);
@@ -167,7 +167,7 @@ public macro fun map_range<$T, $U>($v: &vector<$T>, $start: u64, $end: u64, $f: 
     end_map_lambda<$U>()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun filter_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T| -> bool): &vector<$T> {
     let v = $v;
     let x: &$T = begin_filter_range_lambda<$T>(v, $start, $end);
@@ -175,7 +175,7 @@ public macro fun filter_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |
     end_filter_lambda<$T>()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun find_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T| -> bool): &Option<$T> {
     let v = $v;
     let x: &$T = begin_find_range_lambda<$T>(v, $start, $end);
@@ -183,7 +183,7 @@ public macro fun find_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$
     end_find_lambda<$T>()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun find_index_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T| -> bool): Option<u64> {
     let v = $v;
     let x: &$T = begin_find_index_range_lambda<$T>(v, $start, $end);
@@ -191,7 +191,7 @@ public macro fun find_index_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $
     end_find_index_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun find_indices_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T| -> bool): &vector<u64> {
     let v = $v;
     let x: &$T = begin_find_indices_range_lambda<$T>(v, $start, $end);
@@ -199,7 +199,7 @@ public macro fun find_indices_range<$T>($v: &vector<$T>, $start: u64, $end: u64,
     end_find_indices_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun count_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T| -> bool): u64 {
     let v = $v;
     let x: &$T = begin_count_range_lambda<$T>(v, $start, $end);
@@ -207,7 +207,7 @@ public macro fun count_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&
     end_count_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun any_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T| -> bool): bool {
     let v = $v;
     let x: &$T = begin_any_range_lambda<$T>(v, $start, $end);
@@ -215,7 +215,7 @@ public macro fun any_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T
     end_any_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun all_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T| -> bool): bool {
     let v = $v;
     let x: &$T = begin_all_range_lambda<$T>(v, $start, $end);
@@ -223,7 +223,7 @@ public macro fun all_range<$T>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T
     end_all_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun sum_map_range<$T, $U>($v: &vector<$T>, $start: u64, $end: u64, $f: |&$T| -> $U): Integer {
     let v = $v;
     let x: &$T = begin_sum_map_range_lambda<$T>(v, $start, $end);
@@ -231,21 +231,21 @@ public macro fun sum_map_range<$T, $U>($v: &vector<$T>, $start: u64, $end: u64, 
     end_sum_map_lambda<$U>()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun range_map<$T>($start: u64, $end: u64, $f: |u64| -> $T): &vector<$T> {
     let x: u64 = begin_range_map_lambda($start, $end);
     let _ = $f(x);
     end_range_map_lambda<$T>()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun range_count($start: u64, $end: u64, $f: |u64| -> bool): Integer {
     let x: u64 = begin_range_count_lambda($start, $end);
     let _ = $f(x);
     end_range_count_lambda()
 }
 
-#[spec_only]
+#[mode(spec)]
 public macro fun range_sum_map<$T>($start: u64, $end: u64, $f: |u64| -> $T): Integer {
     let x: u64 = begin_range_sum_map_lambda($start, $end);
     let _ = $f(x);

--- a/packages/sui-specs/sources/sui-framework/event.move
+++ b/packages/sui-specs/sources/sui-framework/event.move
@@ -1,4 +1,4 @@
-#[spec_only]
+#[mode(spec)]
 module specs::event_spec;
 
 use sui::event::{emit, num_events, events_by_type};

--- a/packages/sui-specs/sources/sui-framework/random.move
+++ b/packages/sui-specs/sources/sui-framework/random.move
@@ -2,7 +2,7 @@ module specs::random_spec;
 
 use sui::random::{new_generator, generate_u128_in_range, Random, RandomGenerator};
 use sui::tx_context::TxContext;
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{asserts, ensures};
 
 #[spec(target = sui::random::new_generator)]

--- a/packages/sui-specs/sources/sui-framework/transfer.move
+++ b/packages/sui-specs/sources/sui-framework/transfer.move
@@ -1,8 +1,8 @@
 module specs::transfer_spec;
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::ensures;
-#[spec_only]
+#[mode(spec)]
 use prover::ghost;
 use sui::transfer::{freeze_object_impl, share_object_impl, party_transfer_impl, transfer_impl, receive_impl};
 use sui::object::ID;

--- a/packages/sui-specs/sources/sui-framework/tx_context.move
+++ b/packages/sui-specs/sources/sui-framework/tx_context.move
@@ -15,7 +15,7 @@ use sui::tx_context::{
     native_sponsor
 };
 
-#[spec_only]
+#[mode(spec)]
 use prover::prover::{ensures, clone};
 
 #[spec(target = sui::tx_context::fresh_object_address)]


### PR DESCRIPTION
Replace `#[spec_only]` with the compiler's mode mechanism: spec-only code is now marked #[mode(spec)] and compiled only when the `spec` mode is enabled, which the prover now sets alongside verify_only.

Parameterized payloads move to a companion external attribute:

```
  #[spec_only]                       -> #[mode(spec)]
  #[spec_only(axiom)]                -> #[mode(spec), ext(spec(axiom))]
  #[spec_only(inv_target = T)]       -> #[mode(spec), ext(spec(inv_target = T))]
  #[spec_only(loop_inv(target = f))] -> #[mode(spec), ext(spec(loop_inv(target = f)))]
  #[spec_only(include = p)]          -> #[mode(spec), ext(spec(include = p))]
  #[spec_only(extra_bpl = b"x.bpl")] -> #[mode(spec), ext(spec(extra_bpl = b"x.bpl"))]
```

Entries in one `ext(...)` list must be unique, so repeated `include` or `extra_bpl` values use a parameterized form: `include(a = p1, b = p2)`.

`#[ext(spec(...))]` also currently requires `#[mode(spec)]` on the same item, and `#[spec_only]` in a target module is now an error pointing at the new syntax.  Dependencies (such as the system framework packages) are tolerated to support migration.
